### PR TITLE
Make final field static too to fix technical debt

### DIFF
--- a/com.ca.lsp.cobol/lsp-core-domain/src/main/java/com/broadcom/lsp/domain/cobol/model/CopybookStorable.java
+++ b/com.ca.lsp.cobol/lsp-core-domain/src/main/java/com/broadcom/lsp/domain/cobol/model/CopybookStorable.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Data
 public class CopybookStorable implements Serializable {
-  private final long TTU = 3600L * 3L;
+  private static final long TTU = 3600L * 3L;
 
   private AtomicInteger hit = new AtomicInteger(0);
   private long genDt = Instant.now().getEpochSecond();


### PR DESCRIPTION
Making a public constant just final as opposed to static final leads to duplicating its value for every instance of the class, uselessly increasing the amount of memory required to execute the application.