### PR TITLE
Add uncaught exception handling for async operations #78

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 
 @Slf4j
 public class MyTextDocumentService implements TextDocumentService {
@@ -42,16 +43,19 @@ public class MyTextDocumentService implements TextDocumentService {
   @Override
   public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(
       CompletionParams params) {
-    Completions.checkCompletionParams(params);
-
-    return Completions.collectFor(docs.get(params.getTextDocument().getUri()), params);
+    String uri = params.getTextDocument().getUri();
+    return CompletableFuture.<Either<List<CompletionItem>, CompletionList>>supplyAsync(
+            () -> Either.forRight(Completions.collectFor(docs.get(uri), params)))
+        .whenComplete(
+            reportExceptionIfThrown(createDescriptiveErrorMessage("completion lookup", uri)));
   }
 
   @Override
   public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
-    log.info("Invoked resolving completion for [{}]", unresolved.getLabel());
-
-    return CompletableFuture.supplyAsync(() -> Completions.resolveDocumentationFor(unresolved));
+    return CompletableFuture.supplyAsync(() -> Completions.resolveDocumentationFor(unresolved))
+        .whenComplete(
+            reportExceptionIfThrown(
+                createDescriptiveErrorMessage("completion resolving", unresolved.getLabel())));
   }
 
   @Override
@@ -67,23 +71,28 @@ public class MyTextDocumentService implements TextDocumentService {
   @Override
   public CompletableFuture<List<? extends Location>> definition(
       TextDocumentPositionParams position) {
-    return CompletableFuture.supplyAsync(
-        () -> References.findDefinition(docs.get(position.getTextDocument().getUri()), position));
+    String uri = position.getTextDocument().getUri();
+    return CompletableFuture.<List<? extends Location>>supplyAsync(
+            () -> References.findDefinition(docs.get(uri), position))
+        .whenComplete(reportExceptionIfThrown(createDescriptiveErrorMessage("definitions resolving", uri)));
   }
 
   @Override
   public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-    return CompletableFuture.supplyAsync(
-        () ->
-            References.findReferences(
-                docs.get(params.getTextDocument().getUri()), params, params.getContext()));
+    String uri = params.getTextDocument().getUri();
+    return CompletableFuture.<List<? extends Location>>supplyAsync(
+            () -> References.findReferences(docs.get(uri), params, params.getContext()))
+        .whenComplete(reportExceptionIfThrown(createDescriptiveErrorMessage("references resolving", uri)));
   }
 
   @Override
   public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(
       TextDocumentPositionParams position) {
-    return CompletableFuture.supplyAsync(
-        () -> Highlights.findHighlights(docs.get(position.getTextDocument().getUri()), position));
+    String uri = position.getTextDocument().getUri();
+    return CompletableFuture.<List<? extends DocumentHighlight>>supplyAsync(
+            () -> Highlights.findHighlights(docs.get(uri), position))
+        .whenComplete(
+            reportExceptionIfThrown(createDescriptiveErrorMessage("document highlighting", uri)));
   }
 
   @Override
@@ -99,8 +108,10 @@ public class MyTextDocumentService implements TextDocumentService {
 
   @Override
   public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
-    MyDocumentModel model = docs.get(params.getTextDocument().getUri());
-    return CompletableFuture.supplyAsync(() -> Formations.format(model));
+    String uri = params.getTextDocument().getUri();
+    MyDocumentModel model = docs.get(uri);
+    return CompletableFuture.<List<? extends TextEdit>>supplyAsync(() -> Formations.format(model))
+        .whenComplete(reportExceptionIfThrown(createDescriptiveErrorMessage("formatting", uri)));
   }
 
   @Override
@@ -186,16 +197,18 @@ public class MyTextDocumentService implements TextDocumentService {
               AnalysisResult result = Analysis.run(uri, text);
               docs.get(uri).setAnalysisResult(result);
               publishResult(uri, result);
-            }).whenComplete((res,ex) -> ex.printStackTrace());
+            })
+        .whenComplete(reportExceptionIfThrown(createDescriptiveErrorMessage("analysis", uri)));
   }
 
   private void analyzeChanges(String uri, String text) {
     CompletableFuture.runAsync(
-        () -> {
-          AnalysisResult result = Analysis.run(uri, text);
-          registerDocument(uri, new MyDocumentModel(text, result));
-          communications.publishDiagnostics(uri, result.getDiagnostics());
-        });
+            () -> {
+              AnalysisResult result = Analysis.run(uri, text);
+              registerDocument(uri, new MyDocumentModel(text, result));
+              communications.publishDiagnostics(uri, result.getDiagnostics());
+            })
+        .whenComplete(reportExceptionIfThrown(createDescriptiveErrorMessage("analysis", uri)));
   }
 
   private void publishResult(String uri, AnalysisResult result) {
@@ -206,5 +219,13 @@ public class MyTextDocumentService implements TextDocumentService {
 
   private void registerDocument(String uri, MyDocumentModel document) {
     docs.put(uri, document);
+  }
+
+  private String createDescriptiveErrorMessage(String action, String uri) {
+    return String.format("An exception was thrown while applying %s for %s:", action, uri);
+  }
+
+  private BiConsumer<Object, Throwable> reportExceptionIfThrown(String message) {
+    return (res, ex) -> Optional.ofNullable(ex).ifPresent(it -> log.error(message, it));
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/Completions.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/Completions.java
@@ -18,10 +18,8 @@ import lombok.experimental.UtilityClass;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /** This class is used as a delegate for code completion operations. */
 @UtilityClass
@@ -49,27 +47,12 @@ public class Completions {
   }
 
   /**
-   * Checks the Completion parameters to prevent NullPointerException by throwing an
-   * IllegalArgumentException
-   *
-   * @param params - CompletionParams to be checked
-   */
-  public void checkCompletionParams(CompletionParams params) {
-    if (params.getTextDocument() == null || params.getPosition() == null) {
-      throw new IllegalArgumentException(
-          "The Language Server cannot process an empty CompletionParams instance");
-    }
-  }
-
-  /**
    * Retrieves a list of keywords starting with a provided token.
    *
    * @return A list of keywords that starts with token
    */
-  public CompletableFuture<Either<List<CompletionItem>, CompletionList>> collectFor(
-      MyDocumentModel document, CompletionParams params) {
-    return CompletableFuture.supplyAsync(
-        () -> Either.forRight(new CompletionList(true, collectCompletions(document, params))));
+  public CompletionList collectFor(MyDocumentModel document, CompletionParams params) {
+    return new CompletionList(true, collectCompletions(document, params));
   }
 
   /**
@@ -86,4 +69,5 @@ public class Completions {
       MyDocumentModel document, CompletionParams params) {
     return COMPLETION_PROVIDER.collectCompletions(document, params);
   }
+
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
@@ -45,6 +45,7 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
   private static final String CPY_EXTENSION = "cpy";
   private static final String TEXT_EXAMPLE = "       IDENTIFICATION DIVISION.";
   private static final String INCORRECT_TEXT_EXAMPLE = "       IDENTIFICATION DIVISIONs.";
+
   private TextDocumentService service;
   private TestLanguageClient client;
 
@@ -53,12 +54,6 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
     service = LangServerCtx.getInjector().getInstance(TextDocumentService.class);
     client = LangServerCtx.getInjector().getInstance(TestLanguageClient.class);
     client.clean();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCompletionEmpty() {
-    service.completion(new CompletionParams());
-    fail("No exception were thrown when IllegalArgumentException is expected");
   }
 
   @Test
@@ -100,8 +95,8 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
     DidSaveTextDocumentParams saveDocumentParams =
         new DidSaveTextDocumentParams(saveDocumentIdentifier);
     service.didOpen(
-            new DidOpenTextDocumentParams(
-                    new TextDocumentItem(DOCUMENT_URI, LANGUAGE, 1, TEXT_EXAMPLE)));
+        new DidOpenTextDocumentParams(
+            new TextDocumentItem(DOCUMENT_URI, LANGUAGE, 1, TEXT_EXAMPLE)));
     service.didSave(saveDocumentParams);
     assertTrue(closeGetter(service).containsKey(DOCUMENT_URI));
   }


### PR DESCRIPTION
Log the exceptions that appear within the asynchronous operations in MyTextDocumentService in order to increase code maintainability. Now all the requests will be logged with aa message and the exception's stack trace.