### PR TITLE
[WIP] Remove a circular dependency in the service module #24

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/broadcom/lsp/cdi/module/service/ServiceModule.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/broadcom/lsp/cdi/module/service/ServiceModule.java
@@ -22,6 +22,7 @@ import com.ca.lsp.cobol.service.delegates.ServerCommunications;
 import com.ca.lsp.cobol.service.delegates.validations.CobolLanguageEngineFacade;
 import com.ca.lsp.cobol.service.delegates.validations.LanguageEngineFacade;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
@@ -37,5 +38,6 @@ public class ServiceModule extends DefaultModule {
     bind(CobolWorkspaceService.class).to(CobolWorkspaceServiceImpl.class);
     bind(Communications.class).to(ServerCommunications.class);
     bind(TextDocumentService.class).to(MyTextDocumentService.class);
+    bind(LanguageClient.class).toProvider(MyLanguageServerImpl.class);
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/LangServerBootstrap.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/LangServerBootstrap.java
@@ -19,79 +19,79 @@ import com.broadcom.lsp.cdi.LangServerCtx;
 import com.broadcom.lsp.cdi.module.databus.DatabusModule;
 import com.broadcom.lsp.cdi.module.service.ServiceModule;
 import com.ca.lsp.cobol.service.IMyLanguageServer;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
 
+/**
+ * This class is an entry point for the application. It initializes the DI context and runs the
+ * server to accept the connections using either socket on LSP_PORT or pipes using STDIO. After the
+ * establishing of the connection the main thread suspends until it is stopped forcibly.
+ *
+ * <p>To run the extension using path, you may specify "pipeEnabled" as a program argument. In other
+ * case the server will start using socket.
+ */
 @Slf4j
+@UtilityClass
 public class LangServerBootstrap {
-    private static final Integer LSP_PORT = 1044;
-    private static final String PIPE_ARGM = "pipeEnabled";
-    private IMyLanguageServer server;
+  private static final Integer LSP_PORT = 1044;
+  private static final String PIPE_ARG = "pipeEnabled";
 
-    public LangServerBootstrap() {
-        initCtx();
+  public static void main(String[] args)
+      throws ExecutionException, InterruptedException, IOException {
+    initCtx();
+    IMyLanguageServer server = LangServerCtx.getInjector().getInstance(IMyLanguageServer.class);
+
+    try {
+      Launcher<LanguageClient> launcher = startServer(args, server);
+      server.setClientRemoteProxy(launcher.getRemoteProxy());
+
+      // suspend the main thread on listening
+      launcher.startListening().get();
+    } catch (InterruptedException | ExecutionException e) {
+      log.error("An error occurred while starting a language server", e);
+      throw e;
     }
+  }
 
-    private void initCtx() {
-        LangServerCtx.getGuiceCtx(new ServiceModule(), new DatabusModule());
-        server = LangServerCtx.getInjector().getInstance(IMyLanguageServer.class);
+  void initCtx() {
+    LangServerCtx.getGuiceCtx(new ServiceModule(), new DatabusModule());
+  }
+
+  Launcher<LanguageClient> startServer(String[] args, IMyLanguageServer server) throws IOException {
+    return isPipeEnabled(args)
+        ? createServerLauncher(server, System.in, System.out)
+        : createServerLauncherWithSocket(server);
+  }
+
+  boolean isPipeEnabled(String[] args) {
+    return args.length > 0 && PIPE_ARG.equals(args[0]);
+  }
+
+  Launcher<LanguageClient> createServerLauncherWithSocket(IMyLanguageServer server)
+      throws IOException {
+    try (ServerSocket serverSocket = new ServerSocket(LSP_PORT)) {
+      log.info("Language server started using socket communication on port [{}]", LSP_PORT);
+      // wait for clients to connect
+      Socket socket = serverSocket.accept();
+      return createServerLauncher(server, socket.getInputStream(), socket.getOutputStream());
+    } catch (IOException e) {
+      log.error("Unable to start server using socket communication on port [{}]", LSP_PORT);
+      throw e;
     }
+  }
 
-    public static void main(String[] args) throws InterruptedException, ExecutionException {
-        LangServerBootstrap starter = new LangServerBootstrap();
-        if (args.length > 0) {
-            starter.startLSPServer(args[0]);
-        } else {
-            starter.startLSPServer("socketEnabled");
-        }
-    }
-
-    private void startLSPServer(String pipeEnabled) throws InterruptedException, ExecutionException {
-        if (PIPE_ARGM.equals(pipeEnabled)) {
-            createLSPPipe(server, System.in, System.out);
-        } else {
-            createLSPSocket(server);
-        }
-    }
-
-    private void createLSPSocket(IMyLanguageServer server) {
-        ExecutorService threadPool = Executors.newCachedThreadPool();
-        threadPool.submit(
-                () -> {
-                    while (true) {
-                        try (ServerSocket serverSocket = new ServerSocket(LSP_PORT)) {
-                            log.info("LS started using socket communication on port [{}]", LSP_PORT);
-
-                            // wait for clients to connect
-                            Socket socket = serverSocket.accept();
-
-                            Launcher<LanguageClient> l =
-                                    LSPLauncher.createServerLauncher(
-                                            server, socket.getInputStream(), socket.getOutputStream());
-
-                            // add clients to the server
-                            Runnable addClient = server.setSocketRemoteProxy(l.getRemoteProxy());
-                            l.startListening();
-                            CompletableFuture.runAsync(addClient);
-                        }
-                    }
-                });
-    }
-
-
-    private void createLSPPipe(IMyLanguageServer server, InputStream in, OutputStream out)
-            throws InterruptedException, ExecutionException {
-        Launcher<LanguageClient> l = LSPLauncher.createServerLauncher(server, in, out);
-        Future<?> startListening = l.startListening();
-        server.setPipeRemoteProxy(l.getRemoteProxy());
-        startListening.get();
-    }
+  Launcher<LanguageClient> createServerLauncher(
+      IMyLanguageServer server, InputStream in, OutputStream out) {
+    return LSPLauncher.createServerLauncher(server, in, out);
+  }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/IMyLanguageServer.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/IMyLanguageServer.java
@@ -17,9 +17,5 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 public interface IMyLanguageServer extends LanguageServer {
-  LanguageClient getClient();
-
-  Runnable setSocketRemoteProxy(LanguageClient client);
-
-  void setPipeRemoteProxy(LanguageClient client);
+  void setClientRemoteProxy(LanguageClient client);
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyLanguageServerImpl.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyLanguageServerImpl.java
@@ -31,7 +31,7 @@ public class MyLanguageServerImpl implements Provider<LanguageClient>, IMyLangua
   private final CobolWorkspaceService workspaceService;
 
   @Inject
-  public MyLanguageServerImpl(
+  MyLanguageServerImpl(
       CobolWorkspaceService workspaceService, TextDocumentService textService) {
     this.textService = textService;
     this.workspaceService = workspaceService;
@@ -84,18 +84,8 @@ public class MyLanguageServerImpl implements Provider<LanguageClient>, IMyLangua
   }
 
   @Override
-  public void setPipeRemoteProxy(LanguageClient languageClient) {
+  public void setClientRemoteProxy(LanguageClient languageClient) {
     client = languageClient;
-  }
-
-  @Override
-  public Runnable setSocketRemoteProxy(LanguageClient languageClient) {
-    return () -> client = languageClient;
-  }
-
-  @Override
-  public LanguageClient getClient() {
-    return client;
   }
 
   @Override

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyLanguageServerImpl.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyLanguageServerImpl.java
@@ -14,6 +14,8 @@
 package com.ca.lsp.cobol.service;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -22,7 +24,8 @@ import org.eclipse.lsp4j.services.WorkspaceService;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
-public class MyLanguageServerImpl implements IMyLanguageServer {
+@Singleton
+public class MyLanguageServerImpl implements Provider<LanguageClient>, IMyLanguageServer {
   private LanguageClient client;
   private final TextDocumentService textService;
   private final CobolWorkspaceService workspaceService;
@@ -92,6 +95,11 @@ public class MyLanguageServerImpl implements IMyLanguageServer {
 
   @Override
   public LanguageClient getClient() {
+    return client;
+  }
+
+  @Override
+  public LanguageClient get() {
     return client;
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/ServerCommunications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/ServerCommunications.java
@@ -16,8 +16,8 @@
 
 package com.ca.lsp.cobol.service.delegates;
 
-import com.ca.lsp.cobol.service.IMyLanguageServer;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -40,14 +40,14 @@ import java.util.stream.Collectors;
  * cleaned by removing line breaks to prevent incorrect parsing.
  */
 public class ServerCommunications implements Communications {
-  private final IMyLanguageServer server;
   private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
-
   private final Set<String> uriInProgress = new HashSet<>();
 
+  private Provider<LanguageClient> provider;
+
   @Inject
-  public ServerCommunications(IMyLanguageServer server) {
-    this.server = server;
+  public ServerCommunications(Provider<LanguageClient> provider) {
+    this.provider = provider;
   }
 
   @Override
@@ -117,13 +117,13 @@ public class ServerCommunications implements Communications {
     getClient().showMessage(new MessageParams(type, clean(message)));
   }
 
+  private LanguageClient getClient() {
+    return provider.get();
+  }
+
   private String retrieveFileName(String uri) {
     if (uri.indexOf('/') == -1) return uri;
     return uri.substring(uri.lastIndexOf('/') + 1);
-  }
-
-  private LanguageClient getClient() {
-    return server.getClient();
   }
 
   private List<Diagnostic> clean(List<Diagnostic> diagnostics) {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
@@ -53,6 +53,7 @@ import org.junit.runners.Suite.SuiteClasses;
   CompletionResolutionTest.class,
   WorkspaceServiceTest.class,
   HighlightsTest.class,
-  MultiDocumentDefinitionTest.class
+  MultiDocumentDefinitionTest.class,
+  LangServerBootstrapTest.class
 })
 public class AllTests {}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/LangServerBootstrapTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/LangServerBootstrapTest.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  * Copyright (c) 2019 Broadcom.
+ *  *
+ *  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *  *
+ *  * This program and the accompanying materials are made
+ *  * available under the terms of the Eclipse Public License 2.0
+ *  * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *  *
+ *  * Contributors:
+ *  * Broadcom, Inc. - initial API and implementation
+ *  *
+ *
+ */
+
+package com.ca.lsp.cobol;
+
+import com.broadcom.lsp.cdi.LangServerCtx;
+import com.ca.lsp.cobol.service.IMyLanguageServer;
+import com.ca.lsp.cobol.service.MyLanguageServerImpl;
+import com.ca.lsp.cobol.service.mocks.TestLanguageClient;
+import com.ca.lsp.cobol.service.mocks.TestLanguageServer;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.*;
+
+/** This test check the logic of the application bootstrap */
+public class LangServerBootstrapTest {
+
+  private static final String PIPES = "pipeEnabled";
+
+  @Test
+  public void initCtx() {
+    LangServerBootstrap.initCtx();
+
+    // Bound class in Service module
+    MyLanguageServerImpl server =
+        LangServerCtx.getInjector().getInstance(MyLanguageServerImpl.class);
+    // Bound constant in Databus module
+    Integer cacheSize =
+        LangServerCtx.getInjector()
+            .getInstance(Key.get(Integer.class, Names.named("CACHE-MAX-SIZE")));
+
+    assertNotNull(server);
+    assertNotNull(cacheSize);
+  }
+
+  @Test
+  public void isPipeEnabledPositive() {
+    String[] args = new String[] {PIPES};
+    assertTrue(LangServerBootstrap.isPipeEnabled(args));
+  }
+
+  @Test
+  public void isPipeEnabledUseSocket() {
+    String[] args = new String[] {};
+    assertFalse(LangServerBootstrap.isPipeEnabled(args));
+  }
+
+  @Test
+  public void isPipeEnabledInvalidArgument() {
+    String[] args = new String[] {"invalidArgument"};
+    assertFalse(LangServerBootstrap.isPipeEnabled(args));
+  }
+
+  @Test
+  public void createServerLauncherWithSocket() throws IOException {
+    IMyLanguageServer server = new TestLanguageServer(new TestLanguageClient(), null);
+
+    Executors.newSingleThreadExecutor()
+        .submit(
+            () -> {
+              try {
+                Socket socket = new Socket("127.0.0.1", 1044);
+                assertTrue(socket.isConnected());
+              } catch (IOException e) {
+                fail(e.getMessage());
+              }
+            });
+    Launcher<LanguageClient> launcher = LangServerBootstrap.createServerLauncherWithSocket(server);
+
+    assertNotNull(launcher.getRemoteProxy());
+  }
+
+  @Test
+  public void createServerLauncher() {
+    IMyLanguageServer server = new TestLanguageServer(new TestLanguageClient(), null);
+
+    Launcher<LanguageClient> launcher =
+        LangServerBootstrap.createServerLauncher(server, System.in, System.out);
+
+    assertNotNull(launcher.getRemoteProxy());
+  }
+
+  @Test
+  public void startServer() throws IOException {
+    Launcher<LanguageClient> launcher =
+        LangServerBootstrap.startServer(
+            new String[] {PIPES}, new TestLanguageServer(new TestLanguageClient(), null));
+    assertNotNull(launcher.getRemoteProxy());
+  }
+}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/mocks/TestLanguageServer.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/mocks/TestLanguageServer.java
@@ -15,6 +15,7 @@ package com.ca.lsp.cobol.service.mocks;
 
 import com.ca.lsp.cobol.service.IMyLanguageServer;
 import com.google.inject.Inject;
+import lombok.Getter;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -25,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 
 /** Mock implementation of language server. Only for testing purposes. */
 public class TestLanguageServer implements IMyLanguageServer {
-  private LanguageClient client;
+  @Getter private LanguageClient client;
   private WorkspaceService workspaceService;
 
   @Inject
@@ -60,17 +61,7 @@ public class TestLanguageServer implements IMyLanguageServer {
   }
 
   @Override
-  public LanguageClient getClient() {
-    return client;
-  }
-
-  @Override
-  public Runnable setSocketRemoteProxy(LanguageClient client) {
-    return () -> this.client = client;
-  }
-
-  @Override
-  public void setPipeRemoteProxy(LanguageClient client) {
+  public void setClientRemoteProxy(LanguageClient client) {
     this.client = client;
   }
 }


### PR DESCRIPTION
Make the Server a Client provider in order to remove circular binding ```LanguageServer->TextDocumentService->Communications->LanguageServer```. The server instance is unnecessary for communications because there is only a client proxy required.
The injection of Provider is needed for a lazy client resolution due to the client proxy is available only after a connection, not on a bootstrap stage.