### PR TITLE
Provide the document URI for the language engine

### DIFF
--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/parser/listener/VerboseListener.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/parser/listener/VerboseListener.java
@@ -23,9 +23,11 @@ import java.util.List;
 
 public class VerboseListener extends BaseErrorListener {
   private final List<SyntaxError> errorspipe;
+  private final String documentUri;
 
-  public VerboseListener(List<SyntaxError> errors) {
+  public VerboseListener(List<SyntaxError> errors, String documentUri) {
     errorspipe = errors;
+    this.documentUri = documentUri;
   }
 
   @Override
@@ -43,7 +45,7 @@ public class VerboseListener extends BaseErrorListener {
       CommonToken wrongToken = (CommonToken) offendingSymbol;
       Position position =
           new Position(
-              null,
+              documentUri,
               wrongToken.getStartIndex(),
               wrongToken.getStopIndex(),
               wrongToken.getLine(),
@@ -59,7 +61,8 @@ public class VerboseListener extends BaseErrorListener {
     if (recognizer instanceof Lexer) {
       stack.add(((Lexer) recognizer).getText());
       Position position =
-          new Position(null, charPositionInLine, charPositionInLine, line, charPositionInLine);
+          new Position(
+              documentUri, charPositionInLine, charPositionInLine, line, charPositionInLine);
       errorspipe.add(
           SyntaxError.syntaxError()
               .position(position)

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/CobolPreprocessor.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/CobolPreprocessor.java
@@ -19,8 +19,9 @@ import com.ca.lsp.core.cobol.semantics.SemanticContext;
 
 public interface CobolPreprocessor {
 
-  ResultWithErrors<PreprocessedInput> process(String cobolCode, CobolSourceFormat format);
+  ResultWithErrors<PreprocessedInput> process(
+      String documentUri, String cobolCode, CobolSourceFormat format);
 
   ResultWithErrors<PreprocessedInput> process(
-      String cobolCode, CobolSourceFormat format, SemanticContext semanticContext);
+      String documentUri, String cobolCode, CobolSourceFormat format, SemanticContext semanticContext);
 }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/impl/CobolPreprocessorImpl.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/impl/CobolPreprocessorImpl.java
@@ -13,7 +13,6 @@
  */
 package com.ca.lsp.core.cobol.preprocessor.impl;
 
-import com.ca.lsp.core.cobol.model.CopybookDefinition;
 import com.ca.lsp.core.cobol.model.PreprocessedInput;
 import com.ca.lsp.core.cobol.model.ResultWithErrors;
 import com.ca.lsp.core.cobol.model.SyntaxError;
@@ -39,37 +38,42 @@ import com.ca.lsp.core.cobol.preprocessor.sub.line.writer.impl.CobolLineWriterIm
 import com.ca.lsp.core.cobol.semantics.SemanticContext;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 @Slf4j
 public class CobolPreprocessorImpl implements CobolPreprocessor {
-
+  @Nonnull
   @Override
   public ResultWithErrors<PreprocessedInput> process(
-      final String cobolSourceCode, final CobolSourceFormat format) {
-    return process(cobolSourceCode, format, new SemanticContext(Collections.emptyList()));
+      @Nonnull String documentUri,
+      @Nonnull String cobolSourceCode,
+      @Nonnull CobolSourceFormat format) {
+    return process(
+        documentUri, cobolSourceCode, format, new SemanticContext(Collections.emptyList()));
   }
 
+  @Nonnull
   @Override
   public ResultWithErrors<PreprocessedInput> process(
-      final String cobolCode,
-      final CobolSourceFormat format,
-      final SemanticContext semanticContext) {
-    String documentURI = getDocumentURI(semanticContext);
+      @Nonnull String documentUri,
+      @Nonnull String cobolCode,
+      @Nonnull CobolSourceFormat format,
+      @Nonnull SemanticContext semanticContext) {
 
-    ResultWithErrors<List<CobolLine>> lines = readLines(cobolCode, format, documentURI);
+    ResultWithErrors<List<CobolLine>> lines = readLines(cobolCode, format, documentUri);
 
     ResultWithErrors<List<CobolLine>> transformedLines =
-        transformLines(lines.getResult(), documentURI);
+        transformLines(documentUri, lines.getResult());
 
     List<CobolLine> rewrittenLines = rewriteLines(transformedLines.getResult());
 
-    String cleanDocument = cleanDocument(rewrittenLines, format);
+    String cleanDocument = cleanDocument(documentUri, rewrittenLines, format);
 
     ResultWithErrors<PreprocessedInput> parsedDocument =
-        parseDocument(cleanDocument, format, semanticContext);
+        parseDocument(documentUri, cleanDocument, format, semanticContext);
 
     List<SyntaxError> errors = new ArrayList<>();
     errors.addAll(lines.getErrors());
@@ -79,16 +83,18 @@ public class CobolPreprocessorImpl implements CobolPreprocessor {
     return new ResultWithErrors<>(parsedDocument.getResult(), errors);
   }
 
-  private String cleanDocument(final List<CobolLine> lines, final CobolSourceFormat format) {
+  private String cleanDocument(
+      String documentUri, final List<CobolLine> lines, final CobolSourceFormat format) {
     String code = createLineWriter().serialize(lines);
-    return createDocumentCleaner().cleanDocument(code, format);
+    return createDocumentCleaner().cleanDocument(documentUri, code, format);
   }
 
   private ResultWithErrors<PreprocessedInput> parseDocument(
+      String documentUri,
       final String document,
       final CobolSourceFormat format,
       final SemanticContext semanticContext) {
-    return createDocumentParser().processLines(document, semanticContext, format);
+    return createDocumentParser().processLines(documentUri, document, semanticContext, format);
   }
 
   private ResultWithErrors<List<CobolLine>> readLines(
@@ -97,7 +103,7 @@ public class CobolPreprocessorImpl implements CobolPreprocessor {
   }
 
   private ResultWithErrors<List<CobolLine>> transformLines(
-      List<CobolLine> lines, String documentURI) {
+      String documentURI, List<CobolLine> lines) {
     return createContinuationLineProcessor().transformLines(documentURI, lines);
   }
 
@@ -143,10 +149,5 @@ public class CobolPreprocessorImpl implements CobolPreprocessor {
 
   private CobolLineWriter createLineWriter() {
     return new CobolLineWriterImpl();
-  }
-
-  private String getDocumentURI(SemanticContext semanticContext) {
-    List<CopybookDefinition> tracker = semanticContext.getCopybookUsageTracker();
-    return tracker.isEmpty() ? null : tracker.get(tracker.size() - 1).getUri();
   }
 }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/cleaner/CobolDocumentCleaner.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/cleaner/CobolDocumentCleaner.java
@@ -23,9 +23,10 @@ public interface CobolDocumentCleaner {
   /**
    * Remove the tokens that are not going to be processed from the text
    *
+   * @param documentUri - the URI of the currently processing document
    * @param text - text to be cleaned
    * @param format - format of the document
    * @return cleaned up text
    */
-  String cleanDocument(String text, CobolSourceFormat format);
+  String cleanDocument(String documentUri, String text, CobolSourceFormat format);
 }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/cleaner/impl/CobolDocumentCleanerImpl.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/cleaner/impl/CobolDocumentCleanerImpl.java
@@ -48,12 +48,12 @@ public class CobolDocumentCleanerImpl implements CobolDocumentCleaner {
       };
 
   @Override
-  public String cleanDocument(String text, CobolSourceFormat format) {
+  public String cleanDocument(String documentUri, String text, CobolSourceFormat format) {
     final boolean requiresProcessorExecution = containsTrigger(text, TRIGGERS);
     final String result;
 
     if (requiresProcessorExecution) {
-      result = cleanWithParser(text, format);
+      result = cleanWithParser(documentUri, text, format);
     } else {
       result = text;
     }
@@ -77,7 +77,8 @@ public class CobolDocumentCleanerImpl implements CobolDocumentCleaner {
     return result;
   }
 
-  private String cleanWithParser(final String code, final CobolSourceFormat format) {
+  private String cleanWithParser(
+      final String documentUri, final String code, final CobolSourceFormat format) {
     // run the lexer
     List<SyntaxError> errors = new ArrayList<>();
 
@@ -86,7 +87,7 @@ public class CobolDocumentCleanerImpl implements CobolDocumentCleaner {
 
     // register an error listener, so that preprocessing stops on errors
     lexer.removeErrorListeners();
-    lexer.addErrorListener(new VerboseListener(errors));
+    lexer.addErrorListener(new VerboseListener(errors, documentUri));
 
     // get a list of matched tokens
     final CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -95,7 +96,7 @@ public class CobolDocumentCleanerImpl implements CobolDocumentCleaner {
     final CobolCleanerParser parser = new CobolCleanerParser(tokens);
     // register an error listener, so that preprocessing stops on errors
     parser.removeErrorListeners();
-    parser.addErrorListener(new VerboseListener(errors));
+    parser.addErrorListener(new VerboseListener(errors, documentUri));
 
     // specify our entry point
     CobolCleanerParser.StartCleanContext startRule = parser.startClean();

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/AnalyseCopybookTask.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/AnalyseCopybookTask.java
@@ -142,6 +142,7 @@ public class AnalyseCopybookTask extends RecursiveTask<ResultWithErrors<Copybook
     ResultWithErrors<PreprocessedInput> preprocessedInput =
         getParser()
             .process(
+                copybookDefinition.getUri(),
                 content,
                 format,
                 new SemanticContext(Collections.unmodifiableList(nextTrackerIteration)));

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/AnalyseCopybookTask.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/AnalyseCopybookTask.java
@@ -49,15 +49,18 @@ public class AnalyseCopybookTask extends RecursiveTask<ResultWithErrors<Copybook
       LangServerCtx.getInjector().getInstance(DefaultDataBusBroker.class);
 
   private final String copyBookName;
+  private String documentUri;
   private transient CopybookDefinition copybookDefinition;
   private transient List<CopybookDefinition> copybookUsageTracker;
   private final CobolSourceFormat format;
   private transient CompletableFuture<String> waitForResolving;
 
   public AnalyseCopybookTask(
+      String documentUri,
       CopybookDefinition copybookDefinition,
       List<CopybookDefinition> copybookUsageTracker,
       CobolSourceFormat format) {
+    this.documentUri = documentUri;
     this.copybookDefinition = copybookDefinition;
     copyBookName = copybookDefinition.getName();
     this.copybookUsageTracker = copybookUsageTracker;
@@ -82,7 +85,8 @@ public class AnalyseCopybookTask extends RecursiveTask<ResultWithErrors<Copybook
       semanticContext = parseCopybookFromCache();
     } else {
       Object subscriber = databus.subscribe(DataEventType.FETCHED_COPYBOOK_EVENT, this);
-      databus.postData(RequiredCopybookEvent.builder().name(copyBookName).build());
+      databus.postData(
+          RequiredCopybookEvent.builder().name(copyBookName).documentUri(documentUri).build());
       semanticContext = parseCopybook();
       databus.unSubscribe(subscriber);
     }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/CopybookAnalysis.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/CopybookAnalysis.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 public interface CopybookAnalysis {
   ResultWithErrors<List<CopybookSemanticContext>> analyzeCopybooks(
+      String documentUri,
       Multimap<String, Position> copybookNames,
       List<CopybookDefinition> copybookUsageTracker,
       CobolSourceFormat format);

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/CopybookParallelAnalysis.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/copybook/CopybookParallelAnalysis.java
@@ -36,11 +36,12 @@ public class CopybookParallelAnalysis implements CopybookAnalysis {
 
   @Override
   public ResultWithErrors<List<CopybookSemanticContext>> analyzeCopybooks(
+      String documentUri,
       Multimap<String, Position> copybooks,
       List<CopybookDefinition> copybookUsageTracker,
       CobolSourceFormat format) {
     List<ResultWithErrors<CopybookSemanticContext>> contexts =
-        runAnalysisAsynchronously(copybooks, copybookUsageTracker, format);
+        runAnalysisAsynchronously(documentUri, copybooks, copybookUsageTracker, format);
 
     List<SyntaxError> errors = createMissingCopybookErrors(copybooks, contexts);
 
@@ -50,10 +51,12 @@ public class CopybookParallelAnalysis implements CopybookAnalysis {
   }
 
   private List<ResultWithErrors<CopybookSemanticContext>> runAnalysisAsynchronously(
+      String documentUri,
       Multimap<String, Position> copybooks,
       List<CopybookDefinition> copybookUsageTracker,
       CobolSourceFormat format) {
-    return ForkJoinTask.invokeAll(createTasks(copybooks, copybookUsageTracker, format)).stream()
+    return ForkJoinTask.invokeAll(createTasks(documentUri, copybooks, copybookUsageTracker, format))
+        .stream()
         .map(ForkJoinTask::join)
         .collect(Collectors.toList());
   }
@@ -101,6 +104,7 @@ public class CopybookParallelAnalysis implements CopybookAnalysis {
   }
 
   private List<ForkJoinTask<ResultWithErrors<CopybookSemanticContext>>> createTasks(
+      String documentUri,
       Multimap<String, Position> names,
       List<CopybookDefinition> copybookUsageTracker,
       CobolSourceFormat format) {
@@ -108,7 +112,8 @@ public class CopybookParallelAnalysis implements CopybookAnalysis {
         .map(
             it ->
                 new AnalyseCopybookTask(
-                    new CopybookDefinition(it.getKey(), null, it.getValue()),
+                    documentUri,
+                    new CopybookDefinition(it.getKey(), documentUri, it.getValue()),
                     copybookUsageTracker,
                     format))
         .collect(Collectors.toList());

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/CobolSemanticParser.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/CobolSemanticParser.java
@@ -37,6 +37,7 @@ public interface CobolSemanticParser {
    */
   @Nonnull
   ResultWithErrors<PreprocessedInput> processLines(
+      @Nonnull String uri,
       @Nonnull String code,
       @Nonnull SemanticContext semanticContext,
       @Nonnull CobolSourceFormat format);

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserImpl.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserImpl.java
@@ -70,7 +70,7 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
 
     // analyze contained copy books
     ResultWithErrors<List<CopybookSemanticContext>> contexts =
-        processCopybooks(semanticContext, format);
+        processCopybooks(uri, semanticContext, format);
     contexts.getResult().forEach(semanticContext::merge);
 
     List<SyntaxError> errors = new ArrayList<>(contexts.getErrors());
@@ -83,7 +83,7 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
   }
 
   private ResultWithErrors<List<CopybookSemanticContext>> processCopybooks(
-      @Nonnull SemanticContext semanticContext, CobolSourceFormat format) {
+      String documentUri, @Nonnull SemanticContext semanticContext, CobolSourceFormat format) {
     Multimap<String, Position> copybookNames = semanticContext.getCopybooks().getDefinitions();
 
     if (copybookNames.isEmpty()) {
@@ -92,7 +92,7 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
 
     CopybookAnalysis copybookAnalyzer = createCopybookAnalyzer();
     return copybookAnalyzer.analyzeCopybooks(
-        copybookNames, semanticContext.getCopybookUsageTracker(), format);
+        documentUri, copybookNames, semanticContext.getCopybookUsageTracker(), format);
   }
 
   @Nonnull

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserImpl.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserImpl.java
@@ -48,6 +48,7 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
   @Nonnull
   @Override
   public ResultWithErrors<PreprocessedInput> processLines(
+      @Nonnull String uri,
       @Nonnull String code,
       @Nonnull SemanticContext semanticContext,
       @Nonnull CobolSourceFormat format) {
@@ -64,7 +65,7 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
 
     final ParseTreeWalker walker = new ParseTreeWalker();
     final CobolSemanticParserListener listener =
-        createDocumentParserListener(tokens, semanticContext, format);
+        createDocumentParserListener(uri, tokens, semanticContext, format);
     walker.walk(listener, startRule);
 
     // analyze contained copy books
@@ -96,10 +97,11 @@ public class CobolSemanticParserImpl implements CobolSemanticParser {
 
   @Nonnull
   private CobolSemanticParserListener createDocumentParserListener(
+      @Nonnull String uri,
       @Nonnull CommonTokenStream tokens,
       @Nonnull SemanticContext semanticContext,
       @Nonnull CobolSourceFormat format) {
-    return new CobolSemanticParserListenerImpl(tokens, semanticContext, format);
+    return new CobolSemanticParserListenerImpl(uri, tokens, semanticContext, format);
   }
 
   @Nonnull

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserListenerImpl.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/preprocessor/sub/document/impl/CobolSemanticParserListenerImpl.java
@@ -51,14 +51,17 @@ public class CobolSemanticParserListenerImpl extends CobolPreprocessorBaseListen
   private final Deque<CobolDocumentContext> contexts = new ArrayDeque<>();
   @Getter private final List<SyntaxError> errors = new ArrayList<>();
 
+  private final String documentUri;
   private final BufferedTokenStream tokens;
   private final CobolSourceFormat format;
   private final SemanticContext semanticContext;
 
   CobolSemanticParserListenerImpl(
+      final String documentUri,
       final BufferedTokenStream tokens,
       final SemanticContext semanticContext,
       final CobolSourceFormat format) {
+    this.documentUri = documentUri;
     this.tokens = tokens;
     this.format = format;
     this.semanticContext = semanticContext;
@@ -170,16 +173,11 @@ public class CobolSemanticParserListenerImpl extends CobolPreprocessorBaseListen
 
   private Position retrievePosition(ParserRuleContext token) {
     return new Position(
-        retrieveDocumentURI(),
+        documentUri,
         token.getStart().getStartIndex(),
         token.getStop().getStopIndex(),
         token.getStart().getLine(),
         token.getStart().getCharPositionInLine());
-  }
-
-  private String retrieveDocumentURI() {
-    List<CopybookDefinition> tracker = semanticContext.getCopybookUsageTracker();
-    return tracker.isEmpty() ? null : tracker.get(tracker.size() - 1).getUri();
   }
 
   @Override

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/visitor/CobolVisitor.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/java/com/ca/lsp/core/cobol/visitor/CobolVisitor.java
@@ -31,6 +31,8 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   private static final int SEVERITY_LEVEL = 3;
   private SemanticListener semanticListener = null;
   private SemanticContext semanticContext = null;
+  private String documentUri = null;
+
   private static LevenshteinDistance instance = LevenshteinDistance.getDefaultInstance();
 
   private static int getWrongTokenStopPosition(String wrongToken, int charPositionInLine) {
@@ -53,6 +55,10 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
 
   public void setSemanticContext(SemanticContext context) {
     semanticContext = context;
+  }
+
+  public void setDocumentUri(String documentUri) {
+    this.documentUri = documentUri;
   }
 
   @Override
@@ -169,7 +175,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
 
   private void throwSuggestion(String wrongToken, int startLine, int charPositionInLine) {
     semanticListener.syntaxError(
-        null,
+        documentUri,
         startLine,
         charPositionInLine,
         getWrongTokenStopPosition(wrongToken, charPositionInLine),
@@ -180,7 +186,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   private void getSemanticError(
       String wrongToken, int startLine, int charPositionInLine, String correctWord) {
     semanticListener.syntaxError(
-        null,
+        documentUri,
         startLine,
         charPositionInLine,
         getWrongTokenStopPosition(wrongToken, charPositionInLine),
@@ -241,7 +247,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
 
   private Position retrievePosition(ParserRuleContext ctx) {
     return new Position(
-        null,
+        documentUri,
         ctx.getStart().getStartIndex(),
         ctx.getStart().getStopIndex(),
         ctx.getStart().getLine(),

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/engine/CobolLanguageEngineTest.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/engine/CobolLanguageEngineTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 /** JUnit Test checks with Cobol engine for both positive and negative tests with 3 formats */
 @RunWith(Parameterized.class)
 public class CobolLanguageEngineTest {
+  public static final String DOCUMENT_URI = "file:///c%3A/workspace/document.cbl";
 
   private static final String NEGATIVE_TEXT =
       "        IDENTIFICATION DIVISION. \r\n"
@@ -72,14 +73,14 @@ public class CobolLanguageEngineTest {
   @Test
   public void doCheckNegative() {
     CobolLanguageEngine engine = new CobolLanguageEngine(format);
-    ResultWithErrors<SemanticContext> result = engine.run("1", NEGATIVE_TEXT);
+    ResultWithErrors<SemanticContext> result = engine.run(DOCUMENT_URI, NEGATIVE_TEXT);
     assertEquals(11, result.getErrors().stream().filter(item -> item.getSeverity() == 1).count());
   }
 
   @Test
   public void doCheckPositive() {
     CobolLanguageEngine engine = new CobolLanguageEngine(format);
-    ResultWithErrors<SemanticContext> result = engine.run("1", POSITIVE_TEXT);
+    ResultWithErrors<SemanticContext> result = engine.run(DOCUMENT_URI, POSITIVE_TEXT);
     assertEquals(0, result.getErrors().stream().filter(item -> item.getSeverity() == 1).count());
   }
 }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/engine/CobolLanguageEngineTest.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/engine/CobolLanguageEngineTest.java
@@ -72,14 +72,14 @@ public class CobolLanguageEngineTest {
   @Test
   public void doCheckNegative() {
     CobolLanguageEngine engine = new CobolLanguageEngine(format);
-    ResultWithErrors<SemanticContext> result = engine.run(NEGATIVE_TEXT);
+    ResultWithErrors<SemanticContext> result = engine.run("1", NEGATIVE_TEXT);
     assertEquals(11, result.getErrors().stream().filter(item -> item.getSeverity() == 1).count());
   }
 
   @Test
   public void doCheckPositive() {
     CobolLanguageEngine engine = new CobolLanguageEngine(format);
-    ResultWithErrors<SemanticContext> result = engine.run(POSITIVE_TEXT);
+    ResultWithErrors<SemanticContext> result = engine.run("1", POSITIVE_TEXT);
     assertEquals(0, result.getErrors().stream().filter(item -> item.getSeverity() == 1).count());
   }
 }

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolCleanExtraLanguageTest.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolCleanExtraLanguageTest.java
@@ -178,7 +178,7 @@ public class CobolCleanExtraLanguageTest {
   @Test
   public void positiveErrorTest() {
     CobolLanguageEngine engine = new CobolLanguageEngine(format);
-    ResultWithErrors<SemanticContext> result = engine.run(TEXT_TO_TEST);
+    ResultWithErrors<SemanticContext> result = engine.run("1", TEXT_TO_TEST);
     assertEquals(0, result.getErrors().stream().filter(item -> item.getSeverity() == 1).count());
   }
 

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolVariableCheckTest.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolVariableCheckTest.java
@@ -101,7 +101,7 @@ public class CobolVariableCheckTest {
   @Test
   public void test() {
     CobolLanguageEngine engine = new CobolLanguageEngine(FIXED);
-    ResultWithErrors<SemanticContext> result = engine.run(TEXT_TO_TEST);
+    ResultWithErrors<SemanticContext> result = engine.run("1", TEXT_TO_TEST);
     assertEquals(2, result.getErrors().stream().filter(item -> item.getSeverity() == 3).count());
   }
 }

--- a/com.ca.lsp.cobol/lsp-core-domain/src/main/java/com/broadcom/lsp/domain/cobol/event/model/RequiredCopybookEvent.java
+++ b/com.ca.lsp.cobol/lsp-core-domain/src/main/java/com/broadcom/lsp/domain/cobol/event/model/RequiredCopybookEvent.java
@@ -28,10 +28,12 @@ import lombok.NoArgsConstructor;
 @Data
 public class RequiredCopybookEvent extends DataEvent {
   private String name;
+  private String documentUri;
 
   @Builder
-  public RequiredCopybookEvent(String name) {
+  public RequiredCopybookEvent(String name, String documentUri) {
     super(DataEventType.REQUIRED_COPYBOOK_EVENT, DataEventType.REQUIRED_COPYBOOK_EVENT.getId());
     this.name = name;
+    this.documentUri = documentUri;
   }
 }

--- a/com.ca.lsp.cobol/lsp-core-domain/src/test/java/com/broadcom/lsp/domain/cobol/event/CopybookEventsTest.java
+++ b/com.ca.lsp.cobol/lsp-core-domain/src/test/java/com/broadcom/lsp/domain/cobol/event/CopybookEventsTest.java
@@ -33,7 +33,9 @@ public class CopybookEventsTest extends CopybookStorableProvider {
   private static final String RUNANALYSIS = "RUNANALYSIS";
   private static final String UNKNOWN = "UNKNOWN";
   private static final String COPYBOOK_NAME = "Test";
-  private static final String COPYBOOK_URI = "file:///C:/Users/test/Test.cbl";
+  private static final String COPYBOOK_URI = "file:///C:/Users/test/Test.cpy";
+  private static final String COBOL_FILE_URI = "file:///C:/Users/test/Main.cbl";
+
   private static final String COPYBOOK_CONTENT = "000000 IDENTIFICATION DIVISION.";
 
   /** Test that the RequiredCopybookEvent DTO is correclty populated */
@@ -85,7 +87,7 @@ public class CopybookEventsTest extends CopybookStorableProvider {
   }
 
   private String getRequireCopybookHeader() {
-    return new RequiredCopybookEvent(COPYBOOK_NAME).getHeader();
+    return new RequiredCopybookEvent(COPYBOOK_NAME, COBOL_FILE_URI).getHeader();
   }
 
   private String getFetchCopybookHeader() {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -200,7 +200,7 @@ public class MyTextDocumentService
   private void analyzeDocumentFirstTime(String uri, String text) {
     CompletableFuture.runAsync(
             () -> {
-              AnalysisResult result = engine.analyze(text);
+              AnalysisResult result = engine.analyze(uri, text);
               docs.get(uri).setAnalysisResult(result);
               publishResult(uri, result);
             })
@@ -210,7 +210,7 @@ public class MyTextDocumentService
   private void analyzeChanges(String uri, String text) {
     CompletableFuture.runAsync(
             () -> {
-              AnalysisResult result = engine.analyze(text);
+              AnalysisResult result = engine.analyze(uri, text);
               registerDocument(uri, new MyDocumentModel(text, result));
               communications.publishDiagnostics(uri, result.getDiagnostics());
             })

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/references/SemanticElementOccurrences.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/references/SemanticElementOccurrences.java
@@ -76,13 +76,11 @@ public class SemanticElementOccurrences implements Occurrences {
       @Nonnull TextDocumentPositionParams position,
       @Nonnull Function<SemanticLocations, Map<String, List<Location>>> getOccurrences) {
     String token = retrieveToken(document, position.getPosition());
-    String uri = position.getTextDocument().getUri();
     return semanticLocations.stream()
         .filter(it -> it.containsToken(document, token))
         .map(getOccurrences)
         .map(retrieveLocationsFor(token))
         .flatMap(List::stream)
-        .map(fillUriIfNeeded(uri))
         .collect(Collectors.toList());
   }
 
@@ -105,20 +103,6 @@ public class SemanticElementOccurrences implements Occurrences {
   @Nonnull
   private static Function<Location, DocumentHighlight> toDocumentHighlight() {
     return location -> new DocumentHighlight(location.getRange(), DocumentHighlightKind.Text);
-  }
-
-  /**
-   * If the element is defined in the current document, the location's URI is null by default and
-   * should be replaced with the actual URI
-   *
-   * @param currentDocumentUri - URI of the current document
-   * @return location for the current document or for the copybook
-   */
-  @Nonnull
-  private Function<Location, Location> fillUriIfNeeded(@Nullable String currentDocumentUri) {
-    return location ->
-        new Location(
-            Optional.ofNullable(location.getUri()).orElse(currentDocumentUri), location.getRange());
   }
 
   @Nonnull

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/validations/LanguageEngineFacade.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/validations/LanguageEngineFacade.java
@@ -15,8 +15,9 @@ package com.ca.lsp.cobol.service.delegates.validations;
 
 public interface LanguageEngineFacade {
   /**
+   * @param uri - URI of the processing document to define positions and errors properly
    * @param text of document opened in the client editor
    * @return list of LSP diagnostic object used to display errors in the editor
    */
-  AnalysisResult analyze(String text);
+  AnalysisResult analyze(String uri, String text);
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
@@ -50,6 +50,8 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
   private static final String CPY_EXTENSION = "cpy";
   private static final String TEXT_EXAMPLE = "       IDENTIFICATION DIVISION.";
   private static final String INCORRECT_TEXT_EXAMPLE = "       IDENTIFICATION DIVISIONs.";
+  private static final String DOCUMENT_WITH_ERRORS_URI =
+      "file:///c%3A/workspace/incorrect_document.cbl";
 
   private TextDocumentService service;
   private TestLanguageClient client;
@@ -154,32 +156,29 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
     AnalysisResult resultWithErrors =
         new AnalysisResult(diagnosticsWithErrors, null, null, null, null);
 
-    String correctDocumentUri = "1";
-    String incorrectDocumentUri = "2";
-
-    when(engine.analyze(correctDocumentUri, TEXT_EXAMPLE)).thenReturn(resultNoErrors);
-    when(engine.analyze(incorrectDocumentUri, INCORRECT_TEXT_EXAMPLE)).thenReturn(resultWithErrors);
+    when(engine.analyze(DOCUMENT_URI, TEXT_EXAMPLE)).thenReturn(resultNoErrors);
+    when(engine.analyze(DOCUMENT_WITH_ERRORS_URI, INCORRECT_TEXT_EXAMPLE))
+        .thenReturn(resultWithErrors);
 
     MyTextDocumentService service = verifyServiceStart(communications, engine, broker);
 
-    verifyDidOpen(
-        communications, engine, diagnosticsNoErrors, service, TEXT_EXAMPLE, correctDocumentUri);
+    verifyDidOpen(communications, engine, diagnosticsNoErrors, service, TEXT_EXAMPLE, DOCUMENT_URI);
     verifyDidOpen(
         communications,
         engine,
         diagnosticsWithErrors,
         service,
         INCORRECT_TEXT_EXAMPLE,
-        incorrectDocumentUri);
+        DOCUMENT_WITH_ERRORS_URI);
 
     service.observerCallback(new RunAnalysisEvent());
-    verifyCallback(communications, engine, diagnosticsNoErrors, TEXT_EXAMPLE, correctDocumentUri);
+    verifyCallback(communications, engine, diagnosticsNoErrors, TEXT_EXAMPLE, DOCUMENT_URI);
     verifyCallback(
         communications,
         engine,
         diagnosticsWithErrors,
         INCORRECT_TEXT_EXAMPLE,
-        incorrectDocumentUri);
+        DOCUMENT_WITH_ERRORS_URI);
   }
 
   private List<Diagnostic> createDefaultDiagnostics() {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/HighlightsTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/HighlightsTest.java
@@ -72,13 +72,11 @@ public class HighlightsTest extends ConfigurableTest {
   }
 
   private TextDocumentService service;
-  private TestLanguageClient client;
-  private static final String ID = "id";
 
   @Before
   public void initializeService() {
     service = LangServerCtx.getInjector().getInstance(TextDocumentService.class);
-    client = LangServerCtx.getInjector().getInstance(TestLanguageClient.class);
+    TestLanguageClient client = LangServerCtx.getInjector().getInstance(TestLanguageClient.class);
     client.clean();
     runTextValidation(service, TEXT);
     waitForDiagnostics(client);

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/CompletionsChainTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/CompletionsChainTest.java
@@ -26,8 +26,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static com.ca.lsp.cobol.service.delegates.validations.UseCaseUtils.runTextValidation;
-import static com.ca.lsp.cobol.service.delegates.validations.UseCaseUtils.waitForDiagnostics;
+import static com.ca.lsp.cobol.service.delegates.validations.UseCaseUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -91,7 +90,7 @@ public class CompletionsChainTest extends ConfigurableTest {
   private List<CompletionItem> getCompletionItems(TextDocumentService service, Position position)
       throws InterruptedException, ExecutionException {
     CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions =
-        service.completion(new CompletionParams(new TextDocumentIdentifier("1"), position));
+        service.completion(new CompletionParams(new TextDocumentIdentifier(DOCUMENT_URI), position));
 
     Either<List<CompletionItem>, CompletionList> either = completions.get();
     return either.getRight().getItems();

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/validations/UseCaseUtils.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/validations/UseCaseUtils.java
@@ -36,9 +36,9 @@ import java.util.stream.Collectors;
 /** This utility class provides methods to run use cases with Cobol code examples. */
 @UtilityClass
 public class UseCaseUtils {
-  public static final String LANGUAGE = "cbl";
-  public static final String DOCUMENT_URI = "1";
+  public static final String DOCUMENT_URI = "file:///c%3A/workspace/document.cbl";
 
+  private static final String LANGUAGE = "cbl";
   private static final long MAX_TIME_TO_WAIT = 60000L;
   private static final long TIME_TO_POLL = 10L;
   private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/validations/UseCaseUtils.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/validations/UseCaseUtils.java
@@ -144,7 +144,7 @@ public class UseCaseUtils {
    */
   public static AnalysisResult analyze(String text) {
     return new CobolLanguageEngineFacade(new CobolLanguageEngine(CobolSourceFormat.FIXED))
-        .analyze(text);
+        .analyze(DOCUMENT_URI, text);
   }
 
   /**
@@ -157,7 +157,7 @@ public class UseCaseUtils {
   public static List<Diagnostic> analyzeForErrors(String text) {
     LanguageEngineFacade engine =
         new CobolLanguageEngineFacade(new CobolLanguageEngine(CobolSourceFormat.FIXED));
-    AnalysisResult result = engine.analyze(text);
+    AnalysisResult result = engine.analyze(DOCUMENT_URI, text);
     return result.getDiagnostics().stream()
         .filter(it -> it.getSeverity().getValue() == 1)
         .collect(Collectors.toList());

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/AnalyzeCopybookCaching.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/AnalyzeCopybookCaching.java
@@ -108,6 +108,7 @@ public class AnalyzeCopybookCaching extends ConfigurableTest {
   private void runAnalysis() {
     AnalyseCopybookTask analyseCopybookTask =
         new AnalyseCopybookTask(
+            null,
             new CopybookDefinition(COPYBOOK_NAME, null, null),
             Collections.emptyList(),
             FIXED);


### PR DESCRIPTION
The currently processing document URI is provided to the language engine to keep the document positions filled-in properly. 
Also, it is useful to build a dependency graph.