### PR TITLE
Remove copybook name from the variable list if copybook is missing GH-186

### DIFF
--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolVariableContextTest.java
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/test/java/com/ca/lsp/core/cobol/semantics/CobolVariableContextTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019 Broadcom.
+ *  Copyright (c) 2020 Broadcom.
  *  The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
  *
  *  This program and the accompanying materials are made
@@ -140,6 +140,25 @@ public class CobolVariableContextTest {
   @Test
   public void getVariableByNameBadTest() {
     assertNull(get("NEW-VARIABLE-NOT-CREATED"));
+  }
+
+  /**
+   * Test that {@link CobolVariableContext#removeUnresolvedCopybookMarks} removes all the variables
+   * that have level number '-1'.
+   */
+  @Test
+  public void removeUnresolvedCopybookMarksTest() {
+    CobolVariableContext context = new CobolVariableContext();
+    Position pos = new Position("doc", 0, 1, 0, 0);
+    String cpyMark = "cpyMark";
+
+    context.define(new Variable("-1", cpyMark), pos);
+    context.define(new Variable("0", "var1"), pos);
+    context.define(new Variable("1", "var2"), pos);
+    context.removeUnresolvedCopybookMarks();
+
+    assertEquals(2, context.getAll().size());
+    assertFalse(context.contains(cpyMark));
   }
 
   private boolean isVariableDefinedInStructure(Variable variable, String targetVariableName) {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
@@ -44,7 +44,6 @@ import org.junit.runners.Suite.SuiteClasses;
   ParagraphCompletionTest.class,
   DocumentOccurrencesTest.class,
   DefinitionsAndUsagesTest.class,
-  TestResponsesNotContainLineBreaks.class,
   WorkspaceServiceTest.class,
   CompletionResolutionTest.class,
   FileSystemServiceTest.class,

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestMissingCopybookNotInVariableList.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestMissingCopybookNotInVariableList.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.ca.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cdi.LangServerCtx;
+import com.ca.lsp.cobol.ConfigurableTest;
+import com.ca.lsp.cobol.service.delegates.validations.AnalysisResult;
+import com.ca.lsp.cobol.service.mocks.MockWorkspaceService;
+import org.eclipse.lsp4j.Location;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.ca.lsp.cobol.service.delegates.validations.UseCaseUtils.analyze;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** This test covers case when copybook that was not found appears as a variable. */
+public class TestMissingCopybookNotInVariableList extends ConfigurableTest {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 PARENT. COPY CPYNAME.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "       MOVE 00 TO CHILD1 OF PARENT.";
+
+  public TestMissingCopybookNotInVariableList() {
+
+    MockWorkspaceService workspaceService =
+        LangServerCtx.getInjector().getInstance(MockWorkspaceService.class);
+    workspaceService.setCopybooks(Collections::emptyList);
+  }
+
+  /**
+   * Assert that there is no variable with name 'CPYNAME' in the defined variable list due to the
+   * copybook with this name isn't resolved. There should be only 'PARENT'.
+   */
+  @Test
+  public void test() {
+    AnalysisResult result = analyze(TEXT);
+    Map<String, List<Location>> variableDefinitions = result.getVariableDefinitions();
+
+    assertEquals(variableDefinitions.keySet().toString(), 1, variableDefinitions.size());
+    assertTrue(variableDefinitions.keySet().toString(), variableDefinitions.containsKey("PARENT"));
+  }
+}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/UseCaseSuite.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/UseCaseSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Broadcom.
+ * Copyright (c) 2020 Broadcom.
  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
  *
  * This program and the accompanying materials are made
@@ -33,8 +33,10 @@ import org.junit.runners.Suite.SuiteClasses;
   TestVariablesAreCaseInsensitive.class,
   TestRemarksSectionIsUnsupported.class,
   TestMissingCopybooksReturnsError.class,
+  TestResponsesNotContainLineBreaks.class,
   TestCorrectErrorUnderscorePosition.class,
   TestSameCopybooksWIthDifferentCases.class,
+  TestMissingCopybookNotInVariableList.class,
   TestExtraSymbolsNotCauseErrorOnNextLine.class,
   TestVariableStructureIsBuiltWithCopybooks.class,
   TestCopybookWithRecursiveDependencyIsDetected.class,


### PR DESCRIPTION
In the current solution, there are copybook marks that are used to build the variable structure using copybooks. The scenario when the copybook is missing and the structure cannot be built was not covered and the mark was not removed.
Now variable semantic context has the capability to remove these marks on demand.
