### PR TITLE
Copybook extension check fails

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/MyTextDocumentServiceTest.java
@@ -89,6 +89,17 @@ public class MyTextDocumentServiceTest extends ConfigurableTest {
   }
 
   @Test
+  public void testDidChangeOnCpyFiles() {
+    List<TextDocumentContentChangeEvent> textEdits = new ArrayList<>();
+    textEdits.add(new TextDocumentContentChangeEvent(INCORRECT_TEXT_EXAMPLE));
+    MyTextDocumentService spyService = spy((MyTextDocumentService)service);
+    spyService.didChange(
+        new DidChangeTextDocumentParams(
+            new VersionedTextDocumentIdentifier(CPY_DOCUMENT_URI, 0), textEdits));
+    verify(spyService, never()).analyzeChanges(any(), any());
+  }
+
+  @Test
   public void testDidClose() {
     openAndAwait();
     assertEquals(1, closeGetter(service).size());


### PR DESCRIPTION
Add logic to ignore '*.cpy' files in didChange handler.
Change didOpen logic. Call registerDocument for register only processed documents.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>