### PR TITLE
225 no escape chars in filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the COBOL Language Support extension are documented in this file.
 
 ## [0.x.x] - TBD
+- No escape chars in filename [#228](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/228) Thanks @[zacanbrcom](https://github.com/zacanbrcom)
 - Consume user settings in Copybook Service [#221](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/221) Thanks @[zacanbrcom](https://github.com/zacanbrcom)
 - Modify dep file creation/update process [#209](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/209) Thanks @[zacanbrcom](https://github.com/zacanbrcom)
 - Retrieve settings.json at initialize [#207](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/207) Thanks @[sergiuilie](https://github.com/sergiuilie)

--- a/clients/cobol-lsp-vscode-extension/CHANGELOG.md
+++ b/clients/cobol-lsp-vscode-extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the COBOL Language Support extension are documented in this file.
 
 ## [0.x.x] - TBD
+- No escape chars in filename [#228](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/228) Thanks @[zacanbrcom](https://github.com/zacanbrcom)
 - Consume user settings in Copybook Service [#221](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/221) Thanks @[zacanbrcom](https://github.com/zacanbrcom)
 - Support copybooks downloading [#208](https://github.com/eclipse/che-che4z-lsp-for-cobol/issues/208) Thanks @[ishche](https://github.com/ishche)
 - Modify dep file creation/update process [#209](https://github.com/eclipse/che-che4z-lsp-for-cobol/pull/209) Thanks @[zacanbrcom](https://github.com/zacanbrcom)

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -174,7 +174,6 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
     registerEngineAndAnalyze(uri, langId, text);
   }
 
-  @SneakyThrows
   @Override
   public void didChange(DidChangeTextDocumentParams params) {
     String uri = params.getTextDocument().getUri();

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
 import javax.annotation.Nonnull;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -162,7 +163,8 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   @SneakyThrows
   @Override
   public void didOpen(DidOpenTextDocumentParams params) {
-    String uri = params.getTextDocument().getUri();
+    // decode the URI in UTF-8 to avoid issue with special chars
+    String uri = URLDecoder.decode(params.getTextDocument().getUri(), "UTF-8");
     // A better implementation that will cover the gitfs scenario will be implementated later based
     // on issue #173
     if (uri.startsWith(GIT_FS_URI)) {
@@ -228,7 +230,7 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
     registerDocument(uri, new MyDocumentModel(text, AnalysisResult.empty()));
     runAsync(
             () -> {
-              AnalysisResult result = engine.analyze(uri, text,TextDocumentSyncType.DID_OPEN);
+              AnalysisResult result = engine.analyze(uri, text, TextDocumentSyncType.DID_OPEN);
               ofNullable(docs.get(uri)).ifPresent(doc -> doc.setAnalysisResult(result));
               publishResult(uri, result);
             })
@@ -238,7 +240,7 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   void analyzeChanges(String uri, String text) {
     runAsync(
             () -> {
-              AnalysisResult result = engine.analyze(uri, text,TextDocumentSyncType.DID_CHANGE);
+              AnalysisResult result = engine.analyze(uri, text, TextDocumentSyncType.DID_CHANGE);
               registerDocument(uri, new MyDocumentModel(text, result));
               communications.publishDiagnostics(uri, result.getDiagnostics());
             })

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
 import javax.annotation.Nonnull;
-import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -163,8 +162,7 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   @SneakyThrows
   @Override
   public void didOpen(DidOpenTextDocumentParams params) {
-    // decode the URI in UTF-8 to avoid issue with special chars
-    String uri = URLDecoder.decode(params.getTextDocument().getUri(), "UTF-8");
+    String uri = params.getTextDocument().getUri();
     // A better implementation that will cover the gitfs scenario will be implementated later based
     // on issue #173
     if (uri.startsWith(GIT_FS_URI)) {
@@ -176,6 +174,7 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
     registerEngineAndAnalyze(uri, langId, text);
   }
 
+  @SneakyThrows
   @Override
   public void didChange(DidChangeTextDocumentParams params) {
     String uri = params.getTextDocument().getUri();

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -26,8 +26,6 @@ import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +35,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.ca.lsp.cobol.service.utils.FileSystemUtils.decodeURI;
 
 /**
  * This class serves the communications between server and client. It also allows to send delayable
@@ -191,14 +191,5 @@ public class ServerCommunications implements Communications {
 
   private String clean(String source) {
     return source.replaceAll("(\\r\\n|\\r|\\n)", "");
-  }
-
-  private String decodeURI(String uri) {
-    try {
-      return URLDecoder.decode(uri, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      log.error(e.getMessage());
-      return uri;
-    }
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -19,12 +19,15 @@ package com.ca.lsp.cobol.service.delegates.communications;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +43,7 @@ import java.util.stream.Collectors;
  * messages. Notice, that all the messages that are going to be sent from server to client should be
  * cleaned by removing line breaks to prevent incorrect parsing.
  */
+@Slf4j
 public class ServerCommunications implements Communications {
   private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
   private final Set<String> uriInProgress = new HashSet<>();
@@ -74,11 +78,13 @@ public class ServerCommunications implements Communications {
    */
   @Override
   public void notifyThatLoadingInProgress(String uri) {
-    uriInProgress.add(uri);
+    String decodedUri = decodeURI(uri);
+    uriInProgress.add(decodedUri);
     executor.schedule(
         () -> {
-          if (uriInProgress.remove(uri)) {
-            showMessage(MessageType.Info, retrieveFileName(uri) + ": Syntax analysis in progress");
+          if (uriInProgress.remove(decodedUri)) {
+            showMessage(
+                MessageType.Info, retrieveFileName(decodedUri) + ": Syntax analysis in progress");
           }
         },
         3,
@@ -94,7 +100,9 @@ public class ServerCommunications implements Communications {
   public void notifyThatDocumentAnalysed(String uri) {
     CompletableFuture.runAsync(
         () ->
-            showMessage(MessageType.Info, "No syntax errors detected in " + retrieveFileName(uri)));
+            showMessage(
+                MessageType.Info,
+                "No syntax errors detected in " + retrieveFileName(decodeURI(uri))));
   }
 
   /**
@@ -143,7 +151,8 @@ public class ServerCommunications implements Communications {
    */
   @Override
   public void publishDiagnostics(String uri, List<Diagnostic> diagnostics) {
-    getClient().publishDiagnostics(new PublishDiagnosticsParams(uri, clean(diagnostics)));
+    getClient()
+        .publishDiagnostics(new PublishDiagnosticsParams(decodeURI(uri), clean(diagnostics)));
   }
 
   /**
@@ -153,7 +162,7 @@ public class ServerCommunications implements Communications {
    */
   @Override
   public void cancelProgressNotification(String uri) {
-    uriInProgress.remove(uri);
+    uriInProgress.remove(decodeURI(uri));
   }
 
   private void showMessage(MessageType type, String message) {
@@ -182,5 +191,14 @@ public class ServerCommunications implements Communications {
 
   private String clean(String source) {
     return source.replaceAll("(\\r\\n|\\r|\\n)", "");
+  }
+
+  private String decodeURI(String uri) {
+    try {
+      return URLDecoder.decode(uri, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      log.error(e.getMessage());
+      return uri;
+    }
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/utils/FileSystemUtils.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/utils/FileSystemUtils.java
@@ -21,6 +21,8 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -88,5 +90,22 @@ public class FileSystemUtils {
   public boolean hasFileValidExtension(String fullPath) {
     return ALLOWED_EXTENSIONS.stream()
         .anyMatch(ext -> ext.equalsIgnoreCase(FilenameUtils.getExtension(fullPath)));
+  }
+
+  /**
+   * This method could be used when an URI contains special chars (as parenthesis, spaces and so on)
+   * that are encoded by the LSP protocol on the client side but needs to be encoded in order to
+   * display to the user the uri correctly.
+   *
+   * @param uri provided by the {@link org.eclipse.lsp4j.services.TextDocumentService}
+   * @return a new String decoded with UTF8
+   */
+  public static String decodeURI(String uri) {
+    try {
+      return URLDecoder.decode(uri, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      log.error(e.getMessage());
+      return uri;
+    }
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/utils/FileSystemUtilsTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/utils/FileSystemUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *
+ *   Broadcom, Inc. - initial API and implementation
+ */
+package com.ca.lsp.cobol.utils;
+
+import com.ca.lsp.cobol.service.utils.FileSystemUtils;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertEquals;
+
+/** This class contains unit test about utility methods provided for other components */
+public class FileSystemUtilsTest {
+
+  /**
+   * This unit test verify that for a given URI with encoded special character, the decode operation
+   * will return the original URI before the client encode it.
+   */
+  @Test
+  public void documentUriDecodingTest() throws UnsupportedEncodingException {
+    String decodedURI = "file:///user/COBOL/HLQ0001.DEMO.COBOL(MEMBFILE).cbl";
+    assertEquals(
+        decodedURI,
+        FileSystemUtils.decodeURI("file:///user/COBOL/HLQ0001.DEMO.COBOL%28MEMBFILE%29.cbl"));
+  }
+}


### PR DESCRIPTION
Fix #225 allowing the user to have a decoded URI message info on the ```Communication``` class