### PR TITLE
Fix wrong call to listPathDatasets

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/CopybooksDownloader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/CopybooksDownloader.ts
@@ -66,7 +66,7 @@ export class CopybooksDownloader implements vscode.Disposable {
             missingCopybooks.forEach(copybook => this.queue.push(copybook, profile));
         } else if (missingCopybooks.length > 0) {
             this.resolver.fixMissingDownloads(message, missingCopybooks, profile, {
-                hasPaths: (await this.listPathDatasets()).length > 0,
+                hasPaths: (await this.pathsService.listPathDatasets()).length > 0,
                 hasProfiles: Object.keys(await this.profileService.listProfiles()).length > 1,
             });
         }


### PR DESCRIPTION
The method was invoked as ```this.listPathDatasets()``` but should be ```this.pathsService.listPathDatasets()``` according with the code defined into CopybookDownloader.ts
