### PR TITLE
Hide 'no errors found' message GH-312

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -100,7 +100,7 @@ public class ServerCommunications implements Communications {
   public void notifyThatDocumentAnalysed(String uri) {
     CompletableFuture.runAsync(
         () ->
-            showMessage(
+            logMessage(
                 MessageType.Info,
                 "No syntax errors detected in " + retrieveFileName(decodeURI(uri))));
   }
@@ -167,6 +167,10 @@ public class ServerCommunications implements Communications {
 
   private void showMessage(MessageType type, String message) {
     getClient().showMessage(new MessageParams(type, clean(message)));
+  }
+
+  private void logMessage(MessageType type, String message) {
+    getClient().logMessage(new MessageParams(type, clean(message)));
   }
 
   private LanguageClient getClient() {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
@@ -18,6 +18,7 @@ import com.ca.lsp.cobol.positive.PositiveTest;
 import com.ca.lsp.cobol.service.*;
 import com.ca.lsp.cobol.service.delegates.HighlightsTest;
 import com.ca.lsp.cobol.service.delegates.actions.CodeActionsTest;
+import com.ca.lsp.cobol.service.delegates.communications.ServerCommunicationsTest;
 import com.ca.lsp.cobol.service.delegates.completions.*;
 import com.ca.lsp.cobol.service.delegates.references.DocumentOccurrencesTest;
 import com.ca.lsp.cobol.usecases.UseCaseSuite;
@@ -55,6 +56,7 @@ import org.junit.runners.Suite.SuiteClasses;
   MyLanguageServerImplTest.class,
   DidChangeConfigurationTest.class,
   InitializeConfigurationTest.class,
-  CodeActionsTest.class
+  CodeActionsTest.class,
+  ServerCommunicationsTest.class
 })
 public class AllTests {}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.ca.lsp.cobol.service.delegates.communications;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static com.ca.lsp.cobol.service.delegates.validations.UseCaseUtils.DOCUMENT_URI;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.*;
+
+/** This unit tests verifies the capabilities of {@link ServerCommunications} */
+public class ServerCommunicationsTest {
+  // TODO: Cover the rest of the methods
+  /**
+   * Method {@link ServerCommunications#notifyThatDocumentAnalysed(String)} should asynchronously
+   * call logging on the client for a specific message with a document name retrieved from uri
+   */
+  @Test
+  public void testNotifyThatDocumentAnalysed() {
+    assertDocumentAnalysedNotification(DOCUMENT_URI, "document.cbl");
+    assertDocumentAnalysedNotification("document.cbl", "document.cbl");
+    assertDocumentAnalysedNotification("", "");
+  }
+
+  private void assertDocumentAnalysedNotification(String uri, String fileName) {
+    LanguageClient client = mock(LanguageClient.class);
+    ServerCommunications communications = new ServerCommunications(() -> client);
+    ArgumentCaptor<MessageParams> captor = forClass(MessageParams.class);
+
+    communications.notifyThatDocumentAnalysed(uri);
+    verify(client, timeout(10000).times(1)).logMessage(captor.capture());
+    assertEquals(
+        new MessageParams(MessageType.Info, "No syntax errors detected in " + fileName),
+        captor.getValue());
+  }
+}


### PR DESCRIPTION
In order to limit showing pop-ups silently log notifications that document analyzed with no errors.
close: #312 
fix: #308 