### PR TITLE
build: Change "-NEXT" suffix to "+NEXT"

### DIFF
--- a/clients/cobol-lsp-vscode-extension/releaseScripts/prepare.sh
+++ b/clients/cobol-lsp-vscode-extension/releaseScripts/prepare.sh
@@ -53,7 +53,7 @@ if [ "development" == "$CURRENT_BRANCH" ]; then
     echo "Branch 'release-$SHORT_RELEASE' created and pushed"
 
     git checkout development
-    update_version "$SHORT_RELEASE-NEXT"
+    update_version "$SHORT_RELEASE+NEXT"
     git add package.json ../../com.ca.lsp.cobol/pom.xml server/note.md ../../Jenkinsfile src/extension.ts
     git commit -s -m "chore(release): Switch to development version"
     git push


### PR DESCRIPTION
Current "-NEXT" is pre-release identifier according the SemVer grammar.
After changing to "+NEXT" it will be a build metainfo.
This means that 0.11.1+NEXT and 0.11.1 will have the same precedence.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>