### PR TITLE
Inform user about wrong credentials and stop sending other MF requests

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/CopybooksDownloaderTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/CopybooksDownloaderTest.ts
@@ -14,12 +14,17 @@
 
 import * as vscode from "vscode";
 import { CopybooksDownloader } from "../services/CopybooksDownloader";
+import { CopybooksPathGenerator } from "../services/CopybooksPathGenerator";
+import { CopybookProfile } from "../services/DownloadQueue";
+import { Type, ZoweError } from "../services/ZoweError";
 
 // tslint:disable: no-unused-expression no-string-literal
 describe("Copybook downloader", () => {
     vscode.workspace.workspaceFolders = [{} as any];
     vscode.window.showInformationMessage = () => Promise.resolve("Download Copybooks");
-    const profile = "profile";
+    const profile = "zoweProfile";
+    const copybookProfile = new CopybookProfile("copybook", profile);
+    const zoweGeneralError = new ZoweError("zowe error", Type.General);
     it("Can download copybook", async () => {
 /* WORK IN PROGRESS
         const zoweApi: any = {
@@ -41,5 +46,85 @@ describe("Copybook downloader", () => {
         expect(zoweApi.listZOSMFProfiles).toBeCalled();
 */
 
+    });
+    it("fetchCopybook rethrow ZoweError from zoweApi", async () => {
+        const zoweApi: any = {
+            listMembers: jest.fn().mockRejectedValue(zoweGeneralError),
+        };
+        const cbd = new CopybooksDownloader(null, zoweApi, null, null);
+        expect((cbd as any).fetchCopybook(null, null)).rejects.toEqual(zoweGeneralError);
+    });
+    it("handleCopybook rethrow ZoweError from zoweApi", async () => {
+        const zoweApi: any = {
+            listMembers: jest.fn().mockRejectedValue(zoweGeneralError),
+        };
+        const cbd = new CopybooksDownloader(null, zoweApi, null, null);
+        expect((cbd as any).handleCopybook(null, null, null)).rejects.toEqual(zoweGeneralError);
+    });
+    it("handleDataset rethow non NotFound ZoweErrors", async () => {
+        const cbd = new CopybooksDownloader(null, null, null, null);
+        (cbd as any).handleCopybook = jest.fn().mockRejectedValue(zoweGeneralError);
+        const toDownload = [copybookProfile];
+        const progress = {report: jest.fn()};
+        expect((cbd as any).handleDataset(null, toDownload, null, progress)).rejects.toEqual(zoweGeneralError);
+    });
+    it("handleDataset show an error if copybook is not found", async () => {
+        const zoweError = new ZoweError("not found", Type.NotFound);
+        const cbd = new CopybooksDownloader(null, null, null, null);
+        (cbd as any).handleCopybook = jest.fn().mockRejectedValue(zoweError);
+        const toDownload = [copybookProfile];
+        const progress = {report: jest.fn()};
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleDataset("DATA.SET", toDownload, null, progress);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("Dataset DATA.SET not found.");
+    });
+    it("handleDataset show an error for non ZoweError", async () => {
+        const errorMessage = "The error";
+        const cbd = new CopybooksDownloader(null, null, null, null);
+        (cbd as any).handleCopybook = jest.fn().mockRejectedValue(new Error(errorMessage));
+        const toDownload = [copybookProfile];
+        const progress = {report: jest.fn()};
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleDataset("DATA.SET", toDownload, null, progress);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("Error: " + errorMessage);
+    });
+    it("handleQueue show an error for non ZoweError", async () => {
+        const errorMessage = "The error";
+        const pathGenerator = new CopybooksPathGenerator(null);
+        pathGenerator.listDatasets = jest.fn().mockResolvedValue(["dataset"]);
+        const cbd = new CopybooksDownloader(null, null, null, pathGenerator);
+        (cbd as any).handleDataset = jest.fn().mockRejectedValue(new Error(errorMessage));
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleQueue(copybookProfile, new Set(), null);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("Error: " + errorMessage);
+    });
+    it("handleQueue handle Invalid credentials ZoweError", async () => {
+        const pathGenerator = new CopybooksPathGenerator(null);
+        pathGenerator.listDatasets = jest.fn().mockResolvedValue(["dataset"]);
+        const cbd = new CopybooksDownloader(null, null, null, pathGenerator);
+        (cbd as any).handleDataset = jest.fn().mockRejectedValue(new ZoweError("", Type.InvalidCredentials));
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleQueue(copybookProfile, new Set(), null);
+        expect(vscode.window.showErrorMessage)
+            .toHaveBeenCalledWith("Incorrect credentials in Zowe profile zoweProfile.");
+    });
+    it("handleQueue handle Connection refused ZoweError", async () => {
+        const pathGenerator = new CopybooksPathGenerator(null);
+        pathGenerator.listDatasets = jest.fn().mockResolvedValue(["dataset"]);
+        const cbd = new CopybooksDownloader(null, null, null, pathGenerator);
+        (cbd as any).handleDataset = jest.fn().mockRejectedValue(new ZoweError("", Type.ConnRefused));
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleQueue(copybookProfile, new Set(), null);
+        expect(vscode.window.showErrorMessage)
+            .toHaveBeenCalledWith("Connection to mainframe using Zowe profile zoweProfile failed.");
+    });
+    it("handleQueue handle No password ZoweError", async () => {
+        const pathGenerator = new CopybooksPathGenerator(null);
+        pathGenerator.listDatasets = jest.fn().mockResolvedValue(["dataset"]);
+        const cbd = new CopybooksDownloader(null, null, null, pathGenerator);
+        (cbd as any).handleDataset = jest.fn().mockRejectedValue(new ZoweError("", Type.NoPassword));
+        vscode.window.showErrorMessage = jest.fn();
+        await (cbd as any).handleQueue(copybookProfile, new Set(), null);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("No password in Zowe profile zoweProfile.");
     });
 });

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/ZoweApiTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/ZoweApiTest.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+import { BasicProfileManager, Session } from "@zowe/imperative";
+import { ZoweApi } from "../services/ZoweApi";
+import { Type, ZoweError } from "../services/ZoweError";
+jest.mock("@zowe/imperative");
+
+beforeEach(() => {
+    (BasicProfileManager as any).mockClear();
+});
+
+describe("ZoweApi", () => {
+    it("throw No Password error if profile don't have a password", async () => {
+        (BasicProfileManager as any).load = jest.fn().mockResolvedValue({profile: {password: ""}});
+        const zoweApi = new ZoweApi();
+        const expectedError = new ZoweError("No password", Type.NoPassword);
+        expect(zoweApi.createSession("zoweProfile")).rejects.toEqual(expectedError);
+    });
+    it("createSession works fine if password is set", async () => {
+        (BasicProfileManager as any).load = jest.fn().mockResolvedValue({profile: {password: "secret"}});
+        const zoweApi = new ZoweApi();
+        expect(zoweApi.createSession("zoweProfile")).resolves.toBeInstanceOf(Session);
+    });
+});

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/ZoweErrorTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/ZoweErrorTest.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+
+import {convertError, Type, ZoweError} from "../services/ZoweError";
+import { RestClientError } from "@zowe/imperative";
+
+describe("ZoweError", () => {
+    it("convertError don't change ZoweError", () => {
+        const zoweError = new ZoweError("MSG", Type.General);
+        const result = convertError(zoweError);
+        expect(result).toBe(zoweError);
+    });
+    it("convertError don't change Error", () => {
+        const theError = new Error("MGS");
+        const result = convertError(theError);
+        expect(result).toBe(theError);
+    });
+    it("convertError converts 401 HTTP error to Invalid credentials", () => {
+        const httpError = new RestClientError({errorCode: "401", source: "http", msg: "401 error" });
+        const result = convertError(httpError);
+        expect(result).toBeInstanceOf(ZoweError);
+        expect((<ZoweError>result).type).toBe(Type.InvalidCredentials);
+    });
+    it("convertError converts 404 HTTP error to Not found", () => {
+        const httpError = new RestClientError({errorCode: "404", source: "http", msg: "404 error"});
+        const result = convertError(httpError);
+        expect(result).toBeInstanceOf(ZoweError);
+        expect((<ZoweError>result).type).toBe(Type.NotFound);
+    });
+    it("convertError converts HTTP ECONNREFUSED errors to ConnRefused", () => {
+        const httpError = new RestClientError({source: "http", msg: "Conn refused", causeErrors: {code: "ECONNREFUSED"}});
+        const result = convertError(httpError);
+        expect(result).toBeInstanceOf(ZoweError);
+        expect((<ZoweError>result).type).toBe(Type.ConnRefused);
+    });
+    it("convertError converts HTTP ENOTFOUND errors to ConnRefused", () => {
+        const httpError = new RestClientError({source: "http", msg: "Conn refused", causeErrors: {code: "ENOTFOUND"}});
+        const result = convertError(httpError);
+        expect(result).toBeInstanceOf(ZoweError);
+        expect((<ZoweError>result).type).toBe(Type.ConnRefused);
+    });
+    it("convertError don't change any other RestClientError's", () => {
+        const httpError = new RestClientError({source: "client", msg: "Client error"});
+        const result = convertError(httpError);
+        expect(result).toBe(httpError);
+    });
+});

--- a/clients/cobol-lsp-vscode-extension/src/constants.ts
+++ b/clients/cobol-lsp-vscode-extension/src/constants.ts
@@ -1,3 +1,5 @@
+import { convertError } from "./services/ZoweError";
+
 /*
  * Copyright (c) 2020 Broadcom.
  * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
@@ -17,3 +19,9 @@ export const COPYBOOKS_FOLDER: string = ".copybooks";
 export const LANGUAGE_ID = "COBOL";
 export const REASON_MSG = "Configuration updated. Ensure your configuration contains correct paths to nested copybooks.";
 export const PROCESS_DOWNLOAD_ERROR_MSG = "Some copybooks could not be downloaded. Ensure your configuration contains correct paths to nested copybooks. Missing copybooks: ";
+export const PROFILE_NAME_PLACEHOLDER = "<profilename>";
+export const NO_PASSWORD_ERROR_MSG = `No password in Zowe profile ${PROFILE_NAME_PLACEHOLDER}.`;
+export const CONN_REFUSED_ERROR_MSG = `Connection to mainframe using Zowe profile ${PROFILE_NAME_PLACEHOLDER} failed.`;
+export const INVALID_CREDENTIALS_ERROR_MSG = `Incorrect credentials in Zowe profile ${PROFILE_NAME_PLACEHOLDER}.`;
+export const DSN_PLACEHOLDER = "<DSN>";
+export const DSN_NOT_FOUND_ERROR_MSG = `Dataset ${DSN_PLACEHOLDER} not found.`;

--- a/clients/cobol-lsp-vscode-extension/src/services/CopybooksDownloader.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/CopybooksDownloader.ts
@@ -15,12 +15,13 @@
 import * as fs from "fs";
 import * as vscode from "vscode";
 import { loadDepFile, DependenciesDesc } from "./DependencyService";
-import { DEPENDENCIES_FOLDER, PROCESS_DOWNLOAD_ERROR_MSG } from "../constants";
+import { DEPENDENCIES_FOLDER, PROCESS_DOWNLOAD_ERROR_MSG, DSN_NOT_FOUND_ERROR_MSG, INVALID_CREDENTIALS_ERROR_MSG, DSN_PLACEHOLDER, PROFILE_NAME_PLACEHOLDER, CONN_REFUSED_ERROR_MSG, NO_PASSWORD_ERROR_MSG } from "../constants";
 import { CopybookFix } from "./CopybookFix";
 import { CopybooksPathGenerator, createDatasetPath, createCopybookPath, checkWorkspace } from "./CopybooksPathGenerator";
 import { CopybookProfile, DownloadQueue } from "./DownloadQueue";
 import { ProfileService } from "./ProfileService";
 import { ZoweApi } from "./ZoweApi";
+import { Type, ZoweError } from "./ZoweError";
 
 export class CopybooksDownloader implements vscode.Disposable {
     private queue: DownloadQueue = new DownloadQueue();
@@ -75,7 +76,7 @@ export class CopybooksDownloader implements vscode.Disposable {
     public async start() {
         this.resolver.setQueue(this.queue);
         let done = false;
-        const errors = new Set();
+        const errors = new Set<string>();
         while (!done) {
             const element: CopybookProfile | undefined = await this.queue.pop();
             if (!element) {
@@ -88,27 +89,7 @@ export class CopybooksDownloader implements vscode.Disposable {
                     title: "Fetching copybooks",
                 },
                 async (progress: vscode.Progress<{ message?: string; increment?: number }>) => {
-                    const toDownload: CopybookProfile[] = [element];
-                    while (this.queue.length > 0) {
-                        toDownload.push(await this.queue.pop());
-                    }
-                    toDownload.map(cp => cp.copybook).forEach(cb => errors.add(cb));
-                    for (const dataset of await this.pathGenerator.listDatasets()) {
-                        progress.report({
-                            message: "Looking in " + dataset + ". " + toDownload.length +
-                                " copybook(s) left.",
-                        });
-                        for (const cp of toDownload) {
-                            try {
-                                const fetchResult = await this.fetchCopybook(dataset, cp);
-                                if (fetchResult) {
-                                    errors.delete(cp.copybook);
-                                }
-                            } catch (e) {
-                                vscode.window.showErrorMessage(e.toString());
-                            }
-                        }
-                    }
+                    await this.handleQueue(element, errors, progress);
                     if (this.queue.length === 0 && errors.size > 0) {
                         this.resolver.processDownloadError(PROCESS_DOWNLOAD_ERROR_MSG + Array.from(errors));
                         errors.clear();
@@ -121,11 +102,88 @@ export class CopybooksDownloader implements vscode.Disposable {
         this.queue.stop();
     }
 
+    private async handleQueue(
+            element: CopybookProfile,
+            errors: Set<string>,
+            progress: vscode.Progress<{ message?: string; increment?: number }>) {
+        const toDownload: CopybookProfile[] = [element];
+        while (this.queue.length > 0) {
+            toDownload.push(await this.queue.pop());
+        }
+        toDownload.map(cp => cp.copybook).forEach(cb => errors.add(cb));
+        try {
+            for (const dataset of await this.pathGenerator.listDatasets()) {
+                await this.handleDataset(dataset, toDownload, errors, progress);
+            }
+        } catch (e) {
+            let errorMessage = e.toString();
+            if (e instanceof ZoweError) {
+                switch (e.type) {
+                    case Type.InvalidCredentials:
+                        errorMessage = INVALID_CREDENTIALS_ERROR_MSG.replace(PROFILE_NAME_PLACEHOLDER, element.profile);
+                        break;
+                    case Type.ConnRefused:
+                        errorMessage = CONN_REFUSED_ERROR_MSG.replace(PROFILE_NAME_PLACEHOLDER, element.profile);
+                        break;
+                    case Type.NoPassword:
+                        errorMessage = NO_PASSWORD_ERROR_MSG.replace(PROFILE_NAME_PLACEHOLDER, element.profile);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            vscode.window.showErrorMessage(errorMessage);
+        }
+    }
+
+    private async handleDataset(
+            dataset: string,
+            toDownload: CopybookProfile[],
+            errors: Set<string>,
+            progress: vscode.Progress<{ message?: string; increment?: number }>) {
+        try {
+            progress.report({
+                message: "Looking in " + dataset + ". " + toDownload.length +
+                    " copybook(s) left.",
+            });
+            for (const cp of toDownload) {
+                await this.handleCopybook(dataset, cp, errors);
+            }
+        } catch (e) {
+            let errorMessage = e.toString();
+            if (e instanceof ZoweError) {
+                if (e.type === Type.NotFound) {
+                    errorMessage = DSN_NOT_FOUND_ERROR_MSG.replace(DSN_PLACEHOLDER, dataset);
+                } else {
+                    throw e;
+                }
+            }
+            vscode.window.showErrorMessage(errorMessage);
+        }
+    }
+
+    private async handleCopybook(dataset: string, cp: CopybookProfile, errors: Set<string>) {
+        try {
+            const fetchResult = await this.fetchCopybook(dataset, cp);
+            if (fetchResult) {
+                errors.delete(cp.copybook);
+            }
+        } catch (e) {
+            if (e instanceof ZoweError) {
+                throw e;
+            }
+            vscode.window.showErrorMessage(e.toString());
+        }
+    }
+
     private async fetchCopybook(dataset: string, copybookProfile: CopybookProfile): Promise<boolean> {
         let members: string[] = [];
         try {
             members = await this.zoweApi.listMembers(dataset, copybookProfile.profile);
         } catch (error) {
+            if (error instanceof ZoweError) {
+                throw error;
+            }
             await this.resolver.processDownloadError("Can't read members of dataset: " + dataset);
             return false;
         }

--- a/clients/cobol-lsp-vscode-extension/src/services/ZoweApi.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ZoweApi.ts
@@ -15,6 +15,7 @@
 import { AbstractSession, BasicProfileManager, IProfile, RestClient, Session } from "@zowe/imperative";
 import * as os from "os";
 import * as path from "path";
+import { convertError, Type, ZoweError } from "./ZoweError";
 
 const ZOSMF_PREFIX = "/zosmf/restfiles/ds/";
 
@@ -41,28 +42,39 @@ export class ZoweApi {
     }
 
     public async fetchMember(dataset: string, member: string, profileName: string): Promise<string> {
-        const session: Session = await this.createSession(profileName);
+        try {
+            const session: Session = await this.createSession(profileName);
 
-        // default should be https
-        const rpath = `${ZOSMF_PREFIX}${dataset}(${member})`;
-        return await RestClient.getExpectString(session, rpath, [{
-            "Content-Type": "application/json", "X-CSRF-ZOSMF-HEADER": "",
-        }]);
+            // default should be https
+            const rpath = `${ZOSMF_PREFIX}${dataset}(${member})`;
+            return await RestClient.getExpectString(session, rpath, [{
+                "Content-Type": "application/json", "X-CSRF-ZOSMF-HEADER": "",
+            }]);
+        } catch (error) {
+            throw convertError(error);
+        }
     }
 
     public async listMembers(dataset: string, profileName: string): Promise<string[]> {
-        // default should be https
-        const session: Session = await this.createSession(profileName);
-        const rpath = `${ZOSMF_PREFIX}${dataset}/member`;
-        const result = await RestClient.getExpectJSON(session, rpath, [{
-            "Content-Type": "application/json", "X-CSRF-ZOSMF-HEADER": "",
-        }]);
-        // tslint:disable-next-line: no-string-literal
-        return result["items"].map((i: any) => i.member);
+        try {
+            // default should be https
+            const session: Session = await this.createSession(profileName);
+            const rpath = `${ZOSMF_PREFIX}${dataset}/member`;
+            const result = await RestClient.getExpectJSON(session, rpath, [{
+                "Content-Type": "application/json", "X-CSRF-ZOSMF-HEADER": "",
+            }]);
+            // tslint:disable-next-line: no-string-literal
+            return result["items"].map((i: any) => i.member);
+        } catch (error) {
+            throw convertError(error);
+        }
     }
 
     public async createSession(profileName: string) {
         const profile = (await new BasicProfileManager(this.createProfileParams()).load({ name: profileName })).profile;
+        if (profile.password === "") {
+            throw new ZoweError("No password", Type.NoPassword);
+        }
         return new Session({
             ...{
                 hostname: profile.host,

--- a/clients/cobol-lsp-vscode-extension/src/services/ZoweError.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/ZoweError.ts
@@ -1,0 +1,33 @@
+import { RestClientError } from "@zowe/imperative";
+
+export function convertError(error: any): Error {
+    if (error instanceof RestClientError) {
+        switch (+error.mDetails.errorCode) {
+            case 401:
+                return new ZoweError("Invalid credentials", Type.InvalidCredentials);
+            case 404:
+                return new ZoweError("Not found", Type.NotFound);
+        }
+        if (error.mDetails.causeErrors != null &&
+            (error.mDetails.causeErrors.code === "ECONNREFUSED" ||
+             error.mDetails.causeErrors.code === "ENOTFOUND")) {
+            return new ZoweError(`Connection refused to ${error.mDetails.host}:${error.mDetails.port}`,
+                Type.ConnRefused);
+        }
+    }
+    return error;
+}
+
+export class ZoweError extends Error {
+    constructor(message: string, public type: Type = Type.General) {
+        super(message);
+    }
+}
+
+export enum Type {
+    General,
+    NoPassword,
+    InvalidCredentials,
+    ConnRefused,
+    NotFound,
+}


### PR DESCRIPTION
User was correctly notified if:
* Zowe profile have empty password
* MF API not accessible
* Zowe profile have wrong credentials
* dataset not found

Closes #237

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>