### PR TITLE
Add Jest run on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,6 +154,7 @@ pipeline {
                     steps {
                         container('node') {
                             dir('clients/cobol-lsp-vscode-extension') {
+                                sh 'npm test'
                                 sh 'npx vsce package'
                                 archiveArtifacts "*.vsix"
                                 sh 'mv cobol-language-support*.vsix cobol-language-support_0.11.1-NEXT.vsix'


### PR DESCRIPTION
We have unit tests for TS part. It make sense to run them on CI.

**Must** be tested on separate eclipse branch first!

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>