### PR TITLE
Clarify copybook retrieval setup procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ The LSP for COBOL extension can retrieve copybooks used in your projects from th
 
 #### Retrieving Copybooks
 
-To retrieve copybooks from the mainframe, **follow these steps:**
+To set up automatic copybook retrieval from the mainframe, **follow these steps:**
 
 1. Ensure that you have a [Zowe CLI z/OSMF profile](https://docs.zowe.org/stable/user-guide/cli-configuringcli.html) configured, with credentials defined.
-2. Open the extension settings. 
-3. Under **Paths**, add any number of data sets to search for copybooks. The data sets are searched in the order they are listed, so if two data sets contain a copybook with the same member name, the one from the data set higher on the list is downloaded.
-4. Open a program or project.  
-   All copybooks used in the program or project which are not stored locally are downloaded from the mainframe. Copybooks are stored in a **.copybooks** directory within the workspace, which is created automatically when copybooks are downloaded.
+2. Open the **Extensions** tab, click the cog icon next to **COBOL Language Support** and select **Extension Settings** to open the COBOL Language Support extension settings. 
+3. Under **Paths**, add any number of partitioned data sets to search for copybooks. The data sets are searched in the order they are listed, so if two data sets contain a copybook with the same member name, the one from the data set higher on the list is downloaded.
+4. Under **Profile**, enter the name of your Zowe CLI z/OSMF profile.
+5. Open a program or project.  
+   All copybooks used in the program or project which are not stored locally are downloaded from the mainframe data sets listed in the extension preferences. Copybooks are stored locally in a **.copybooks** directory within the workspace, which is created automatically.
    
    **Tip:** Because copybooks that are downloaded to the .copybooks folder might change on the mainframe, we recommend that you refresh your copybooks from time to time. To refresh your copybooks, manually delete the hidden .copybooks folder in your workspace. The copybooks are then re-downloaded from the mainframe the next time you open a file that references each copybook.
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ To set up automatic copybook retrieval from the mainframe, **follow these steps:
 
 1. Ensure that you have a [Zowe CLI z/OSMF profile](https://docs.zowe.org/stable/user-guide/cli-configuringcli.html) configured, with credentials defined.
 2. Open the **Extensions** tab, click the cog icon next to **COBOL Language Support** and select **Extension Settings** to open the COBOL Language Support extension settings. 
-3. Under **Paths**, add any number of partitioned data sets to search for copybooks. The data sets are searched in the order they are listed, so if two data sets contain a copybook with the same member name, the one from the data set higher on the list is downloaded.
+3. Under **Paths**, list the names of any number of partitioned data sets on the mainframe to search for copybooks. The data sets are searched in the order they are listed, so if two data sets contain a copybook with the same member name, the one from the data set higher on the list is downloaded.
 4. Under **Profile**, enter the name of your Zowe CLI z/OSMF profile.
 5. Open a program or project.  
-   All copybooks used in the program or project which are not stored locally are downloaded from the mainframe data sets listed in the extension preferences. Copybooks are stored locally in a **.copybooks** directory within the workspace, which is created automatically.
+   All copybooks used in the program or project which are not stored locally are downloaded from the mainframe data sets that you specified in step 3. Copybooks are stored locally in a **.copybooks** directory within the workspace, which is created automatically.
    
    **Tip:** Because copybooks that are downloaded to the .copybooks folder might change on the mainframe, we recommend that you refresh your copybooks from time to time. To refresh your copybooks, manually delete the hidden .copybooks folder in your workspace. The copybooks are then re-downloaded from the mainframe the next time you open a file that references each copybook.
 


### PR DESCRIPTION
I've clarified the copybook retrieval setup procedure
- given the clearest possible instructions to access the COBOL LS extension preferences, since in Code4z the bitlang plugin has similar features in its extension preferences
- added a new step to add the zowe profile name
- clarified that copybooks need to be stored in PDSes.
