### PR TITLE
IntegrationTests: Fix warnings and change tags 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ pipeline {
                 }
                 container('python') {
                     dir('tests/theia_automation_lsp') {
-                        sh 'HOME=`pwd`/robot_home PYTHONPATH=`pwd` robot -i Rally -e Unstable --variable HEADLESS:True --outputdir robot_output robot_suites/lsp/local/firefox_lsp_local.robot'
+                        sh 'HOME=`pwd`/robot_home PYTHONPATH=`pwd` robot -i Rally -e NEED_UPDATE -e DEFECT_OPEN --variable HEADLESS:True --outputdir robot_output robot_suites/lsp/local/firefox_lsp_local.robot'
                     }
                 }
             }

--- a/tests/theiaPrepare.sh
+++ b/tests/theiaPrepare.sh
@@ -26,3 +26,5 @@ cp *.vsix /home/theia/plugins/
 
 cd /home/theia
 nohup yarn theia start /home/project --hostname=0.0.0.0 > theia.log &
+echo "Waiting for Theia starting..."
+sed '/Deploy plugins list took/q' <(tail -n 0 -f /home/theia/theia.log) > /dev/null

--- a/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
+++ b/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
@@ -492,8 +492,8 @@ TC152051 Syntax Errors have more detailed hints
     @{ERROR_LINES} =  Find Lines With Errors  ${Editor}  ${Active Editor}
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
-    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  @{LINES}[0]  ${Active Editor}
-    Should Be Equal  @{LINES}[0]   ${Error Line Number}
+    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  ${LINES}[0]  ${Active Editor}
+    Should Be Equal  ${LINES}[0]   ${Error Line Number}
     Should Be Equal  ${Error Hint}  ${Tooltip Text}
 
     ${Active Tab} =  Get Active Tab  ${Editor}
@@ -701,8 +701,8 @@ Check incorrect Local Cobol File - Full Scenario
     Sleep  1
 
     ${Active Editor} =  Get Active Editor  ${Editor}
-    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  @{LINES}[0]  ${Active Editor}
-    Should Be Equal  @{LINES}[0]   ${Error Line Number}
+    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  ${LINES}[0]  ${Active Editor}
+    Should Be Equal  ${LINES}[0]   ${Error Line Number}
     Should Be Equal  ${Error Hint}  ${Tooltip Text}
 
     ${Int Line} =  Convert To Integer   ${Semantic Error Line}
@@ -809,7 +809,7 @@ TC174956 Copybook - not exist: error underlined
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True  @{Lines}[0] == ${Copy Line 1}
+    Should Be True  ${Lines}[0] == ${Copy Line 1}
 
     ${Editor} =  Get Editor
     ${Active Tab} =  Get Active Tab  ${Editor}
@@ -836,7 +836,7 @@ TC174658 Copybook - not exist: detailed hint
     @{ERROR_LINES} =  Find Lines With Errors  ${Editor}  ${Active Editor}
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
-    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  @{LINES}[0]  ${Active Editor}
+    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  ${LINES}[0]  ${Active Editor}
     Should Be Equal  ${Copybook Not Found Hint}  ${Tooltip Text}
 
     ${Editor} =  Get Editor
@@ -866,7 +866,7 @@ TC174916 Copybook - recursive error
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True   @{LINES}[0] == ${Copy Line 1}
+    Should Be True   ${LINES}[0] == ${Copy Line 1}
 
     ${Editor} =  Get Editor
     ${Active Tab} =  Get Active Tab  ${Editor}
@@ -890,7 +890,7 @@ TC174917 Copybook - recursive detailed hint
     @{ERROR_LINES} =  Find Lines With Errors  ${Editor}  ${Active Editor}
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
-    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  @{LINES}[0]  ${Active Editor}
+    ${Tooltip Text} =  Show Error Tooltip For Line Number  ${Editor}  ${LINES}[0]  ${Active Editor}
     Should Be Equal  ${Copybook Recursive Error Hint}  ${Tooltip Text}
 
     ${Editor} =  Get Editor
@@ -1092,7 +1092,7 @@ TC174952 Copybook - not exist, but dynamically appears
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True  @{Lines}[0] == ${Copy Line 1}
+    Should Be True  ${Lines}[0] == ${Copy Line 1}
 
     Copy File Macro    ${Copybook Missing Src Path}   ${Copybook Missing Path}   ${Copybook Missing}.cpy
 
@@ -1113,7 +1113,7 @@ TC174952 Copybook - not exist, but dynamically appears
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True  @{Lines}[0] == ${Copy Line 1}
+    Should Be True  ${Lines}[0] == ${Copy Line 1}
 
 TC174953 Copybook - definition not exist, but dynamically appears
     [Tags]  TC174953  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
@@ -1143,7 +1143,7 @@ TC174953 Copybook - definition not exist, but dynamically appears
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True  @{Lines}[0] == ${References Line 1}
+    Should Be True  ${Lines}[0] == ${References Line 1}
 
     Copy File Macro  ${Copybook Missing Src Path}   ${Copybook Missing Path}   ${Copybook Missing}.cpy
 
@@ -1171,4 +1171,4 @@ TC174953 Copybook - definition not exist, but dynamically appears
     ${LINES} =  Create List  @{ERROR_LINES}
     Log  ${LINES}
     Mark Lines  ${Editor}  ${LINES}  ${Active Editor}
-    Should Be True  @{Lines}[0] == ${References Line 1}
+    Should Be True  ${Lines}[0] == ${References Line 1}

--- a/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
+++ b/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
@@ -114,7 +114,7 @@ SuiteInit
     Log  Heasless: ${HEADLESS}
 
     CheShare  &{CHE_CREDENTIALS}
-    ${CREDENTIALS} =  CheRequest  &{CHE_CREDENTIALS}[password]
+    ${CREDENTIALS} =  CheRequest  ${CHE_CREDENTIALS}[password]
 
     Log  ${CREDENTIALS}
 
@@ -276,14 +276,15 @@ Navigate To Element Path
     ${Last Element} =  Set Variable  ${Element Path}[-1]
     Log  ${Last Element}
 
-    :For  ${subpath}  IN  @{Element Path}
-    \   Log  ${subpath}
-    \   Exit For Loop If  '${subpath}' == '${Last Element}'
-    \   ${Element} =  Inside File Explorer Navigate Down To ${subpath} From ${From Element}
-    \   ${IS_DIR} =  Is Directory  ${Element}
-    \   Exit For Loop If  ${IS_DIR} == ${FALSE}
-    \   Expand Directory Node  ${Element}
-    \   ${From Element} =  Set Variable  ${Element}
+    FOR  ${subpath}  IN  @{Element Path}
+       Log  ${subpath}
+       Exit For Loop If  '${subpath}' == '${Last Element}'
+       ${Element} =  Inside File Explorer Navigate Down To ${subpath} From ${From Element}
+       ${IS_DIR} =  Is Directory  ${Element}
+       Exit For Loop If  ${IS_DIR} == ${FALSE}
+       Expand Directory Node  ${Element}
+       ${From Element} =  Set Variable  ${Element}
+    END
 
     Return From Keyword If  ${Is File Exist} == ${False}  ${Element}
 

--- a/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
+++ b/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
@@ -294,7 +294,7 @@ Navigate To Element Path
 
 *** Test Cases ***
 TC152046 Nominal - check syntax Ok message
-    [Tags]  TC152046  COBOL_LOCAL  LSP  FireFox  Rally  Unstable
+    [Tags]  TC152046  COBOL_LOCAL  LSP  FireFox  Rally  NEED_UPDATE
     [Documentation]  Checks that when opening Cobol file with correct syntax there is an appropriate message is shown
     ${Explorer Title Node} =  Find File Explorer Panel
     ${Top File Element} =  Find First Element In Files Explorer
@@ -404,7 +404,7 @@ TC152080 Find all references from the word begin
     Close Tab  ${Editor}  ${Active Tab}
 
 TC152080 Find all references from the word middle
-    [Tags]  TC152080  COBOL_LOCAL  LSP  FireFox  Rally  Unstable
+    [Tags]  TC152080  COBOL_LOCAL  LSP  FireFox  Rally  DEFECT_OPEN  DE465817
     [Documentation]  Checks that LSP can find all references and navigate by them
     ${Explorer Title Node} =  Find File Explorer Panel
     ${Top File Element} =  Find First Element In Files Explorer
@@ -750,7 +750,7 @@ Check incorrect Local Cobol File - Full Scenario
 # Copybooks
 
 TC174655 Copybook - Nominal
-    [Tags]  TC174655  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174655  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  NEED_UPDATE
     [Documentation]  Checks that when opening Cobol file with correct reference to copybook,
          ...  there is syntax ok message shown
 
@@ -788,7 +788,7 @@ TC174657 Copybook - not exist: no syntax ok message
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174956 Copybook - not exist: error underlined
-    [Tags]  TC174956  COBOL_LOCAL  LSP  FireFox  Rally  Copybook
+    [Tags]  TC174956  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that error lines are marked in a file
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -816,7 +816,7 @@ TC174956 Copybook - not exist: error underlined
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174658 Copybook - not exist: detailed hint
-    [Tags]  TC174658  COBOL_LOCAL  LSP  FireFox  Rally  Copybook
+    [Tags]  TC174658  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that error lines for missing copybook have detailed hints
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -844,7 +844,7 @@ TC174658 Copybook - not exist: detailed hint
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174916 Copybook - recursive error
-    [Tags]  TC174916  COBOL_LOCAL  LSP  FireFox  Rally  Copybook
+    [Tags]  TC174916  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that when opening Cobol file which recursively refers to copybooks,
         ...  copybook is underlined with an error
 
@@ -873,7 +873,7 @@ TC174916 Copybook - recursive error
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174917 Copybook - recursive detailed hint
-    [Tags]  TC174917  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174917  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that when opening Cobol file which recursively refers to copybooks,
         ...  have detailed error hint
 
@@ -898,7 +898,7 @@ TC174917 Copybook - recursive detailed hint
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174932 Copybook - invalid definition
-    [Tags]  TC174932  COBOL_LOCAL  LSP  FireFox  Rally  Copybook
+    [Tags]  TC174932  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that when opening Cobol file which uses invalid definition from copybook,
        ...   this definition is underlined as a semantic error
 
@@ -926,7 +926,7 @@ TC174932 Copybook - invalid definition
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174933 Copybook - invalid definition hint
-    [Tags]  TC174933  COBOL_LOCAL  LSP  FireFox  Rally  Copybook
+    [Tags]  TC174933  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that when opening Cobol file which uses invalid definition from copybook,
        ...   has detailed hint on mouse hover
 
@@ -954,7 +954,7 @@ TC174933 Copybook - invalid definition hint
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174918 Copybook - peek definition
-    [Tags]  TC174918  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174918  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that Peek Definition functionality works in theia in cobol file via context menu
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -988,7 +988,7 @@ TC174918 Copybook - peek definition
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174930 Copybook - Ctrl+Click on definition
-    [Tags]  TC174930  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174930  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that Peek Definition functionality works in theia in cobol file via Ctrl+Click
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -1020,7 +1020,7 @@ TC174930 Copybook - Ctrl+Click on definition
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174931 Copybook - peek references
-    [Tags]  TC174931  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174931  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that LSP can find all references (also in copybooks) and navigate by them
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -1066,7 +1066,7 @@ TC174931 Copybook - peek references
     Close Tab  ${Editor}  ${Active Tab}
 
 TC174952 Copybook - not exist, but dynamically appears
-    [Tags]  TC174952  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174952  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that LSP can dynamically detect appearance of copybook and rescan cobol file on the fly
 
     # Modify User Preferences With Datasets and Zowe Profile Macro
@@ -1116,7 +1116,7 @@ TC174952 Copybook - not exist, but dynamically appears
     Should Be True  @{Lines}[0] == ${Copy Line 1}
 
 TC174953 Copybook - definition not exist, but dynamically appears
-    [Tags]  TC174953  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  Unstable
+    [Tags]  TC174953  COBOL_LOCAL  LSP  FireFox  Rally  Copybook  DEFECT_OPEN  DE465210
     [Documentation]  Checks that LSP can dynamically detect definitions from an appeared
         ...   copybook and rescan cobol file on the fly
 


### PR DESCRIPTION
Right now we have all tests that fail with tag `Unstable`. After analysis, I saw that most of them failed because of defects not because they are unstable. 
So I propose to have a specific tag `DEFECT_OPEN` with a defect ID and also create a tag for tests that need updates (e.g., `NEED_UPDATE`). 

Also about warnings:
https://groups.google.com/forum/#!topic/robotframework-users/PsnmoUKnQpk

```
The old way to access items in a variable containing a list or a
dictionary has been `@{list}[0]` or `&{dict}[key]`, respectively. This
didn't work well with nested lists/dictionaries and RF 3.1 unified the
syntax to use `${list}[0]` or `${dict}[key]` instead [6]. The old
the syntax will be deprecated in RF 3.2 [7] and it's a good idea to change
to the new syntax already before that unless older RF versions need to
be supported. 
``` 

from `requirements.txt` robotframework>=3.1.1

Test results are below:

```
$ PYTHONPATH=$HOME/vboxshare/che-che4z-lsp-for-cobol/tests/theia_automation_lsp/:/home/maryna/public python3  -m robot -i "Rally" -e "NEED_UPDATE" -e "DEFECT_OPEN" --variable HEADLESS:True --outputdir robot_output /home/maryna/vboxshare/che-che4z-lsp-for-cobol/tests/theia_automation_lsp/robot_suites/lsp/local/firefox_lsp_local.robot
```

```
==============================================================================
Firefox Lsp Local :: Test suite for Firefox                                   
==============================================================================
TC152048 Cobol file is recognized by LSP :: Cobol file is recogniz... | PASS |
------------------------------------------------------------------------------
TC152049 Navigate through definitions :: Check behavior of go to d... | PASS |
------------------------------------------------------------------------------
TC152080 Find all references from the word begin :: Checks that LS... | PASS |
------------------------------------------------------------------------------
TC152047 Error case - file has syntax errors :: Checks that when o... | PASS |
------------------------------------------------------------------------------
TC152052 Syntax Errors are marked in file :: Checks that error lin... | PASS |
------------------------------------------------------------------------------
TC152051 Syntax Errors have more detailed hints :: Checks that err... | PASS |
------------------------------------------------------------------------------
TC152050 Semantic Errors also marked in file :: Checks that Semant... | PASS |
------------------------------------------------------------------------------
TC152053 Semantic Errors also have hints :: Checks that semantic e... | PASS |
------------------------------------------------------------------------------
TC152054 Auto format of right trailing spaces :: Checks that auto ... | PASS |
------------------------------------------------------------------------------
TC152058 Autocomplete functionality with snippets navigation :: Ch... | PASS |
------------------------------------------------------------------------------
TC174657 Copybook - not exist: no syntax ok message :: Checks that... | PASS |
------------------------------------------------------------------------------
Firefox Lsp Local :: Test suite for Firefox                           | PASS |
11 critical tests, 11 passed, 0 failed
11 tests total, 11 passed, 0 failed
```