### PR TITLE
Avoid many error messages for copybook downloading

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/CopybookDownloadServiceTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/CopybookDownloadServiceTest.ts
@@ -189,7 +189,7 @@ describe("Validate download copybooks from mainframe with correct and incorrect 
 
         profileService.resolveProfile = jest.fn().mockReturnValue(profileName);
         const spy = jest.spyOn(copybookFix, spyMethod);
-        await copybooksDownloader.downloadCopybook("copybook", "CBLPRG");
+        await copybooksDownloader.downloadCopybooks("copybook", ["CBLPRG"]);
         expect(spy).toBeCalledTimes(toBeCalledTimes);
     }
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/MiddlewareTest.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/MiddlewareTest.ts
@@ -28,9 +28,9 @@ describe("Copybook downloader", () => {
     const copybookResolverURI: any = {
         resolveCopybookURI: resolveCopybookURIMock,
     };
-    const downloadCopybookMock = jest.fn().mockResolvedValue(null);
+    const downloadCopybooksMock = jest.fn().mockResolvedValue(null);
     const copybookDownloader: any = {
-        downloadCopybook: downloadCopybookMock,
+        downloadCopybooks: downloadCopybooksMock,
     };
     const middleware = new Middleware(copybookResolverURI, copybookDownloader);
 
@@ -51,11 +51,10 @@ describe("Copybook downloader", () => {
     it("Handle copybook download request", async () => {
         const params = {items: [
             "broadcom-cobol-lsp.copybook-download.cobFile.bookName",
-            "broadcom-cobol-lsp.copybook-download.USER.CLIST.COB.bookName",
+            "broadcom-cobol-lsp.copybook-download.cobFile.bookName2",
         ].map(sectionName => ({section: sectionName}))};
         await expect(middleware.handleConfigurationRequest(params, null, null)).resolves.toEqual([]);
-        expect(downloadCopybookMock).toHaveBeenCalledWith("cobFile", "bookName");
-        expect(downloadCopybookMock).toHaveBeenCalledWith("USER.CLIST.COB", "bookName");
+        expect(downloadCopybooksMock).toHaveBeenCalledWith("cobFile", ["bookName", "bookName2"]);
     });
     it("Call next for non cobol params", async () => {
         const params = constructParams("foo.bar");

--- a/clients/cobol-lsp-vscode-extension/src/commands/FetchCopybookCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/FetchCopybookCommand.ts
@@ -14,5 +14,5 @@
 import {CopybookDownloadService} from "../services/CopybookDownloadService";
 
 export function fetchCopybookCommand(copybook: string, downloader: CopybookDownloadService, programName: string) {
-    downloader.downloadCopybook(programName, copybook);
+    downloader.downloadCopybooks(programName, [copybook]);
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/CopybookDownloadService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/CopybookDownloadService.ts
@@ -47,16 +47,16 @@ export class CopybookDownloadService implements vscode.Disposable {
      * @param cobolFileName name of the document open in workspace
      * @param copybookName name of the copybook required by the LSP server
      */
-    public async downloadCopybook(cobolFileName: string, copybookName: string): Promise<void> {
+    public async downloadCopybooks(cobolFileName: string, copybookNames: string[]): Promise<void> {
         if (!checkWorkspace()) {
             return;
         }
         const profile: string = await this.profileService.resolveProfile(cobolFileName);
         if (!profile) {
-            this.createErrorMessageForCopybooks(new Set<string>().add(copybookName));
+            this.createErrorMessageForCopybooks(new Set<string>(copybookNames));
             return;
         }
-        await this.resolver.addCopybookInQueue([copybookName], profile);
+        await this.resolver.addCopybookInQueue(copybookNames, profile);
 
     }
 

--- a/clients/cobol-lsp-vscode-extension/src/services/Middleware.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Middleware.ts
@@ -41,10 +41,9 @@ export class Middleware {
                 return [await this.copybookResolverURI.resolveCopybookURI(copybookName, cobolFileName)];
             }
             if (sectionName.startsWith("broadcom-cobol-lsp.copybook-download")) {
-                for (const item of params.items) {
-                    const [cobolFileName, copybookName] = Middleware.extractFileAndCopybookNames(item.section);
-                    this.copybookDownloader.downloadCopybook(cobolFileName, copybookName);
-                }
+                const extractedNames = params.items.map(item => Middleware.extractFileAndCopybookNames(item.section));
+                const copybookNames = extractedNames.map(names => names[1]);
+                this.copybookDownloader.downloadCopybooks(extractedNames[0][0], copybookNames);
                 return [];
             }
         }


### PR DESCRIPTION
Doing existing profile check once for all list of downloading copybooks.
Not for each copybook individually.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>