### PR TITLE
refactor: Remove popup message for GIT unsupported operation #318

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -16,8 +16,8 @@ package com.ca.lsp.cobol.service;
 
 import com.broadcom.lsp.domain.cobol.databus.api.DataBusBroker;
 import com.broadcom.lsp.domain.cobol.event.api.EventObserver;
-import com.broadcom.lsp.domain.cobol.event.model.DataEventType;
 import com.broadcom.lsp.domain.cobol.event.model.AnalysisFinishedEvent;
+import com.broadcom.lsp.domain.cobol.event.model.DataEventType;
 import com.broadcom.lsp.domain.cobol.event.model.RunAnalysisEvent;
 import com.ca.lsp.cobol.service.delegates.actions.CodeActions;
 import com.ca.lsp.cobol.service.delegates.communications.Communications;
@@ -63,6 +63,7 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 public class MyTextDocumentService implements TextDocumentService, EventObserver<RunAnalysisEvent> {
   private static final List<String> COBOL_IDS = Arrays.asList("cobol", "cbl", "cob");
   private static final String GIT_FS_URI = "gitfs:/";
+  public static final String GITFS_URI_NOT_SUPPORTED = "GITFS URI not supported";
 
   private final Map<String, MyDocumentModel> docs = new ConcurrentHashMap<>();
 
@@ -166,10 +167,10 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   @Override
   public void didOpen(DidOpenTextDocumentParams params) {
     String uri = params.getTextDocument().getUri();
-    // A better implementation that will cover the gitfs scenario will be implementated later based
-    // on issue #173
+
+    // git FS URIs are not currently supported
     if (uri.startsWith(GIT_FS_URI)) {
-      communications.notifyThatExtensionIsUnsupported("gitfs");
+      log.warn(String.join(" ", GITFS_URI_NOT_SUPPORTED, uri));
     }
 
     String text = params.getTextDocument().getText();

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/Communications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/Communications.java
@@ -32,8 +32,4 @@ public interface Communications {
   void notifyThatDocumentAnalysed(String uri);
 
   void notifyThatExtensionIsUnsupported(String extension);
-
-  void notifyCopybookMessageInfo(CopybookMessageInfo copybookMessageInfo);
-
-  void notifyLogMessageInfo(CopybookMessageInfo copybookMessageInfo);
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -120,30 +120,6 @@ public class ServerCommunications implements Communications {
   }
 
   /**
-   * This method raise a popup message back to the user with a message customized by the enumeration
-   * class
-   *
-   * @param copybookMessageInfo the enum kind that represent the event that will be shown to the
-   *     user
-   */
-  @Override
-  public void notifyCopybookMessageInfo(CopybookMessageInfo copybookMessageInfo) {
-    CompletableFuture.runAsync(
-        () ->
-            showMessage(
-                MessageType.Error,
-                "Error during the copybook analysis, reason: " + copybookMessageInfo.getMessage()));
-  }
-
-  @Override
-  public void notifyLogMessageInfo(CopybookMessageInfo copybookMessageInfo) {
-    CompletableFuture.runAsync(
-        () ->
-            getClient()
-                .logMessage(new MessageParams(MessageType.Info, copybookMessageInfo.getMessage())));
-  }
-
-  /**
    * This method raise a diagnostic message to the client with syntax error retrivied by the Cobol
    * LSP server
    *


### PR DESCRIPTION
Purpose of this PR is to fix the issue #318 that inform user when a file under git vsc is opened with a popup that produce no value after all because the document is still evaluated by the LSP.
