### PR TITLE
Doc: Add compatibility section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ COBOL Language Support is also part of [Code4z](https://marketplace.visualstudio
 - To enable automatic copybook retrieval, the following are required:
     - Configured TSO/E address space services, z/OS data set and file REST interface, and z/OS jobs REST interface. For more information, see [z/OS Requirements](https://docs.zowe.org/stable/user-guide/systemrequirements-zosmf.html#z-os-requirements).
     - [Zowe CLI z/OSMF profile](https://docs.zowe.org/stable/user-guide/cli-configuringcli.html) with credentials.
+    
+## Compatibility
+
+The COBOL Language Support extension is not compatible with other extensions that provide COBOL support, with the exception of Bitlang's COBOL extension. We recommend that you disable all other COBOL-related extensions to ensure that COBOL Language Support functions correctly.
 
 ## Features
 COBOL Language Support provides the following COBOL syntax awareness features:


### PR DESCRIPTION
Added a new section to the readme to warn of incompatibility with other COBOL related plugins (such as Z Open Editor). 