### PR TITLE
ci: disable too many notifications from semantic-release tool

### DIFF
--- a/clients/cobol-lsp-vscode-extension/.releaserc.yaml
+++ b/clients/cobol-lsp-vscode-extension/.releaserc.yaml
@@ -12,4 +12,9 @@ plugins:
     - @semantic-release/changelog
     - - @semantic-release/exec
       - prepareCmd: releaseScripts/prepare.sh ${nextRelease.version} ${branch.name} "${nextRelease.notes}"
-    - @semantic-release/github
+    - - "@semantic-release/github"
+      - successComment: false
+        failComment: false
+        failTitle: false
+        labels: false
+        releasedLabels: false


### PR DESCRIPTION
Disable adding comments to each PR about it is included into the
release.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>