### PR TITLE
Dispose diagnostic messages when user close the document #385

### DIFF
--- a/clients/cobol-lsp-vscode-extension/.vscode/settings.json
+++ b/clients/cobol-lsp-vscode-extension/.vscode/settings.json
@@ -13,12 +13,15 @@
  */
 // Place your settings in this file to overwrite default and user settings.
 {
-	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
-	},
-	"search.exclude": {
-		"out": true // set this to false to include "out" folder in search results
-	},
+    "files.exclude": {
+        "out": false
+        // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true
+        // set this to false to include "out" folder in search results
+    },
     "typescript.tsdk": "./node_modules/typescript/lib",
-    "vsicons.presets.angular": false, // we want to use the TS server from our node_modules folder to control its version
+    "vsicons.presets.angular": false
+    // we want to use the TS server from our node_modules folder to control its version
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -193,7 +193,8 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   @Override
   public void didClose(DidCloseTextDocumentParams params) {
     String uri = params.getTextDocument().getUri();
-    log.info("Document closing invoked");
+    log.info(String.format("Document closing invoked on URI %s", uri));
+    communications.publishDiagnostics(uri, List.of());
     docs.remove(uri);
   }
 


### PR DESCRIPTION
Close #385 
Purpose of this PR is to clean up the problem area when the document is closed by the user.
According to the LSP protocol, client is responsible to:
- clean up problems notified in problem area
- restore the file text in the explorer removing the red font that highlight a file that contains problems.