### PR TITLE
Fix syntax analysis termination with unexpected copy statements #464

### DIFF
--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/antlr4/com/ca/lsp/core/cobol/parser/CobolLexer.g4
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/antlr4/com/ca/lsp/core/cobol/parser/CobolLexer.g4
@@ -13,6 +13,7 @@
  */
     
 lexer grammar CobolLexer;
+channels{TECHNICAL}
 
 LEVEL: ([1-9])|([0][1-9])|([1234][0-9])| '77';
 LEVEL_NUMBER_66 : '66';
@@ -594,8 +595,8 @@ PLUSCHAR : '+';
 SINGLEQUOTE : '\'';
 RPARENCHAR : ')';
 SLASHCHAR : '/';
-COPYENTRY: ('*>CPYENTER<URI>' .*? '</URI>');
-COPYEXIT: '*>CPYEXIT' + NEWLINE;
+COPYENTRY: ('*>CPYENTER<URI>' .*? '</URI>') -> channel(TECHNICAL);
+COPYEXIT: '*>CPYEXIT' + NEWLINE -> channel(TECHNICAL);
 
 INTEGERLITERAL : (PLUSCHAR | MINUSCHAR)? DIGIT+;
 

--- a/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/antlr4/com/ca/lsp/core/cobol/parser/CobolParser.g4
+++ b/com.ca.lsp.cobol/lsp-core-cobol-parser/src/main/antlr4/com/ca/lsp/core/cobol/parser/CobolParser.g4
@@ -941,7 +941,7 @@ otherLevel: LEVEL
 // end of data description utils ---------------------------
 
 dataDescriptionEntry
-   : dataDescriptionEntryFormat1 | dataDescriptionEntryFormat2 | dataDescriptionEntryFormat3 | dataDescriptionEntryExecSql | dataDescriptionEntryCpy | dataDescriptionExitCpy
+   : dataDescriptionEntryFormat1 | dataDescriptionEntryFormat2 | dataDescriptionEntryFormat3 | dataDescriptionEntryExecSql
    ;
 
 dataDescriptionEntryFormat1
@@ -958,14 +958,6 @@ dataDescriptionEntryFormat3
 
 dataDescriptionEntryExecSql
    : execSqlStatement+
-   ;
-
-dataDescriptionEntryCpy
-   : COPYENTRY
-   ;
-
-dataDescriptionExitCpy
-   : COPYEXIT
    ;
    
 dataGroupUsageClause
@@ -1153,7 +1145,7 @@ paragraph
    ;
 
 sentence
-   : (statement* DOT_FS) | skipStatement+ | enterCpy | exitCpy
+   : (statement* DOT_FS) | skipStatement+
    ;
 
 statement
@@ -1162,15 +1154,7 @@ statement
     exitStatement | generateStatement | gobackStatement | goToStatement | ifStatement | initializeStatement | initiateStatement | inspectStatement | mergeStatement | moveStatement | 
     multiplyStatement | openStatement | performStatement | purgeStatement | readStatement | receiveStatement | releaseStatement | returnStatement | rewriteStatement | searchStatement | 
     sendStatement | serviceReloadStatement | serviceLabelStatement | setStatement | sortStatement | startStatement | stopStatement | stringStatement | subtractStatement |
-    terminateStatement | titleStatement | unstringStatement | writeStatement | xmlStatement | enterCpy | exitCpy
-   ;
-
-enterCpy
-   : COPYENTRY
-   ;
-
-exitCpy
-   : COPYEXIT
+    terminateStatement | titleStatement | unstringStatement | writeStatement | xmlStatement
    ;
 
 // accept statement

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestExtraneousInputEOFExpecting.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestExtraneousInputEOFExpecting.java
@@ -41,7 +41,7 @@ class TestExtraneousInputEOFExpecting {
           + "INITIATE, INSPECT, MERGE, MOVE, MULTIPLY, OPEN, PERFORM, PURGE, READ, "
           + "RECEIVE, RELEASE, RETURN, REWRITE, SEARCH, SEND, SERVICE, SET, SORT, "
           + "START, STOP, STRING, SUBTRACT, TERMINATE, TITLE, UNSTRING, WRITE, XML, "
-          + "DOT_FS, COPYENTRY, COPYEXIT}";
+          + "DOT_FS}";
 
   @Test
   void test() {

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestMissingCopybookAtBeginningNotBreaksSyntaxAnalysis.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestMissingCopybookAtBeginningNotBreaksSyntaxAnalysis.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.ca.lsp.cobol.usecases;
+
+import com.ca.lsp.cobol.service.delegates.validations.SourceInfoLevels;
+import com.ca.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/** Test missing copybook at the beginning doesn't break the syntax analysis */
+class TestMissingCopybookAtBeginningNotBreaksSyntaxAnalysis {
+
+  private static final String TEXT =
+      "       COPY {~ASDAW|1}.\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TESTREPL.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*PARENT} PIC 9.\n"
+          + "       PROCEDURE DIViSION. \n"
+          + "       {#*MAINLINE}. \n"
+          + "           MOVE 0 TO {$PARENT}. \n"
+          + "           GOBACK.  ";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        List.of(),
+        Map.of(
+            "1",
+            new Diagnostic(
+                null,
+                "ASDAW: Copybook not found",
+                DiagnosticSeverity.Error,
+                SourceInfoLevels.ERROR.getText(),
+                "MISSING_COPYBOOK")));
+  }
+}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestReplacingWithDifferentPatternsShowsError.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/usecases/TestReplacingWithDifferentPatternsShowsError.java
@@ -54,7 +54,7 @@ class TestReplacingWithDifferentPatternsShowsError {
       "Syntax error on 'COPY' expected {<EOF>, LEVEL, '66', '88', "
           + "COMMUNICATION, DATA_BASE, END, EXEC, FILE, ID, IDENTIFICATION, "
           + "LINKAGE, LOCAL_STORAGE, PROCEDURE, PROGRAM_LIBRARY, REPORT, "
-          + "SCREEN, WORKING_STORAGE, COPYENTRY, COPYEXIT}";
+          + "SCREEN, WORKING_STORAGE}";
 
   @Test
   void test() {


### PR DESCRIPTION
Pass copy enter and exit tags to a special channel to skip them on parsing