### PR TITLE
Remove +NEXT from hardcoded version

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package-lock.json
+++ b/clients/cobol-lsp-vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cobol-language-support",
-    "version": "0.13.0+NEXT",
+    "version": "0.13.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -4,7 +4,7 @@
     "description": "Autocomplete, highlighting and diagnostics for COBOL code and copybooks.",
     "author": "Broadcom",
     "license": "EPL-2.0",
-    "version": "0.13.0+NEXT",
+    "version": "0.13.0",
     "preview": false,
     "publisher": "BroadcomMFD",
     "engines": {


### PR DESCRIPTION
On CI/CD the build number is added after version and result (like
0.13.0+NEXT+PR-492.6) is not valid.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>