### PR TITLE
Disable extension is unsupported error message

### DIFF
--- a/server/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
+++ b/server/src/main/java/com/ca/lsp/cobol/service/MyTextDocumentService.java
@@ -213,10 +213,7 @@ public class MyTextDocumentService implements TextDocumentService, EventObserver
   }
 
   private void registerEngineAndAnalyze(String uri, String languageType, String text) {
-    String fileExtension = extractExtension(uri);
-    if (fileExtension != null && !isCobolFile(fileExtension)) {
-      communications.notifyThatExtensionIsUnsupported(fileExtension);
-    } else if (isCobolFile(languageType)) {
+    if (isCobolFile(languageType)) {
       communications.notifyThatLoadingInProgress(uri);
       analyzeDocumentFirstTime(uri, text);
     } else {


### PR DESCRIPTION
If user change document type to COBOL, it will be processed as a COBOL
file.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>