### PR TITLE
Exclude Junit 4 dependencies

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -86,6 +86,10 @@
                     <groupId>org.sonatype.sisu</groupId>
                     <artifactId>sisu-guice</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -151,6 +155,12 @@
             <artifactId>junit-platform-runner</artifactId>
             <version>${junit.platform.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtilsTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtilsTest.java
@@ -18,7 +18,7 @@ package com.broadcom.lsp.cobol.core.semantics.outline;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,57 +26,60 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RangeUtilsTest {
+class RangeUtilsTest {
   private Position firstLine = new Position(1, 0);
   private Position secondLine = new Position(2, 0);
 
   @Test
-  public void isAfterPositive() {
+  void isAfterPositive() {
     assertTrue(RangeUtils.isAfter(secondLine, firstLine));
   }
 
   @Test
-  public void isAfterNegative() {
+  void isAfterNegative() {
     assertFalse(RangeUtils.isAfter(firstLine, secondLine));
   }
 
   @Test
-  public void isBeforePositive() {
+  void isBeforePositive() {
     assertTrue(RangeUtils.isBefore(firstLine, secondLine));
   }
 
   @Test
-  public void isBeforeNegative() {
+  void isBeforeNegative() {
     assertFalse(RangeUtils.isBefore(secondLine, firstLine));
   }
 
   @Test
-  public void isPositionsAreEquals() {
+  void isPositionsAreEquals() {
     assertFalse(RangeUtils.isAfter(firstLine, firstLine));
     assertFalse(RangeUtils.isBefore(secondLine, secondLine));
   }
 
-  private static DocumentSymbol constructNode(int startLine, int startSymbol, int stopLine, int stopSymbol) {
-    Range range = new Range(new Position(startLine, startSymbol), new Position(stopLine, stopSymbol));
+  private static DocumentSymbol constructNode(
+      int startLine, int startSymbol, int stopLine, int stopSymbol) {
+    Range range =
+        new Range(new Position(startLine, startSymbol), new Position(stopLine, stopSymbol));
     return new DocumentSymbol("", NodeType.FIELD.getSymbolKind(), range, range, "", List.of());
   }
 
-  public static Stream<Arguments> provideData() {
+  static Stream<Arguments> provideData() {
     return Stream.of(
         Arguments.of(constructNode(1, 1, 10, 1), constructNode(3, 40, 5, 10), true),
         Arguments.of(constructNode(5, 1, 5, 20), constructNode(5, 3, 5, 10), true),
         Arguments.of(constructNode(4, 1, 6, 7), constructNode(3, 40, 6, 3), false),
         Arguments.of(constructNode(4, 1, 6, 8), constructNode(4, 5, 7, 5), false),
         Arguments.of(constructNode(2, 1, 2, 9), constructNode(3, 1, 3, 8), false),
-        Arguments.of(constructNode(5, 1, 5, 20), constructNode(5, 3, 5, 30), false)
-    );
+        Arguments.of(constructNode(5, 1, 5, 20), constructNode(5, 3, 5, 30), false));
   }
 
   @ParameterizedTest
   @MethodSource("provideData")
-  public void isInside(DocumentSymbol first, DocumentSymbol second, boolean result) {
+  void isInside(DocumentSymbol first, DocumentSymbol second, boolean result) {
     assertEquals(result, RangeUtils.isInsideRange(first, second));
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookProcessingModeTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookProcessingModeTest.java
@@ -14,10 +14,10 @@
  */
 package com.broadcom.lsp.cobol.service;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static com.broadcom.lsp.cobol.service.CopybookProcessingMode.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CopybookProcessingModeTest {
   private static final String EXT_SRC_DOC_URI = "file:///c%3A/.c4z/.extsrcs/EXTSRC.cbl";
@@ -32,13 +32,13 @@ class CopybookProcessingModeTest {
    */
   @Test
   void disableCopybookOnExtendedDocument() {
-    Assert.assertEquals(CopybookProcessingMode.DISABLED, CopybookProcessingMode.getCopybookProcessingMode(EXT_SRC_DOC_URI, CopybookProcessingMode.ENABLED));
-    Assert.assertEquals(CopybookProcessingMode.DISABLED, CopybookProcessingMode.getCopybookProcessingMode(EXT_SRC_DOC_URI, CopybookProcessingMode.SKIP));
+    assertEquals(DISABLED, getCopybookProcessingMode(EXT_SRC_DOC_URI, ENABLED));
+    assertEquals(DISABLED, getCopybookProcessingMode(EXT_SRC_DOC_URI, SKIP));
   }
 
   @Test
   void enableCopybookOnNonExtendedDocumentInDidOpen() {
-    Assert.assertEquals(CopybookProcessingMode.ENABLED, CopybookProcessingMode.getCopybookProcessingMode(DOC_URI, CopybookProcessingMode.ENABLED));
+    assertEquals(ENABLED, getCopybookProcessingMode(DOC_URI, ENABLED));
   }
 
   /**
@@ -48,7 +48,7 @@ class CopybookProcessingModeTest {
    */
   @Test
   void enableCopybookOnFakeURI() {
-    Assert.assertEquals(CopybookProcessingMode.ENABLED, CopybookProcessingMode.getCopybookProcessingMode(FAKE_EXT_SRC_DOC_URI, CopybookProcessingMode.ENABLED));
+    assertEquals(ENABLED, getCopybookProcessingMode(FAKE_EXT_SRC_DOC_URI, ENABLED));
   }
 
   /**
@@ -57,6 +57,6 @@ class CopybookProcessingModeTest {
    */
   @Test
   void enableCopybookOnBadExtendedSourceFolders() {
-    Assert.assertEquals(CopybookProcessingMode.ENABLED, CopybookProcessingMode.getCopybookProcessingMode(WRONG_EXT_SRC_DOC_URI, CopybookProcessingMode.ENABLED));
+    assertEquals(ENABLED, getCopybookProcessingMode(WRONG_EXT_SRC_DOC_URI, ENABLED));
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookCaching.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookCaching.java
@@ -15,17 +15,17 @@
 
 package com.broadcom.lsp.cobol.usecases;
 
-import com.broadcom.lsp.cobol.domain.modules.EngineModule;
+import com.broadcom.lsp.cobol.core.model.CopybookModel;
+import com.broadcom.lsp.cobol.core.model.Locality;
+import com.broadcom.lsp.cobol.core.preprocessor.delegates.resolution.CopybookResolutionProvider;
+import com.broadcom.lsp.cobol.domain.databus.api.DataBusBroker;
 import com.broadcom.lsp.cobol.domain.modules.DatabusModule;
+import com.broadcom.lsp.cobol.domain.modules.EngineModule;
 import com.broadcom.lsp.cobol.positive.CobolText;
 import com.broadcom.lsp.cobol.service.CopybookProcessingMode;
 import com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils;
 import com.broadcom.lsp.cobol.service.mocks.MockCopybookService;
 import com.broadcom.lsp.cobol.service.mocks.MockCopybookServiceImpl;
-import com.broadcom.lsp.cobol.core.preprocessor.delegates.resolution.CopybookResolutionProvider;
-import com.broadcom.lsp.cobol.domain.databus.api.DataBusBroker;
-import com.broadcom.lsp.cobol.core.model.CopybookModel;
-import com.broadcom.lsp.cobol.core.model.Locality;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Guice;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test checks the caching logic performed by copybook resolution. The cache invalidated before

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestMarginAB.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestMarginAB.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.analyze;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** This test verifies if the margins respected and warnings thrown */
 class TestMarginAB {
@@ -160,7 +159,8 @@ class TestMarginAB {
 
   @Test
   void checkCorrectProgramID() {
-    AnalysisResult result = UseCaseUtils.analyze(UseCaseUtils.DOCUMENT_URI, TEXT_PROGRAM_ID, List.of());
+    AnalysisResult result =
+        UseCaseUtils.analyze(UseCaseUtils.DOCUMENT_URI, TEXT_PROGRAM_ID, List.of());
 
     assertEquals(1, result.getDiagnostics().size());
     assertEquals(
@@ -170,11 +170,12 @@ class TestMarginAB {
 
   @Test
   void checkDeclaratives() {
-    AnalysisResult result = UseCaseUtils.analyze(UseCaseUtils.DOCUMENT_URI, TEXT_DECLARATIVES, List.of());
+    AnalysisResult result =
+        UseCaseUtils.analyze(UseCaseUtils.DOCUMENT_URI, TEXT_DECLARATIVES, List.of());
 
     assertEquals(3, result.getDiagnostics().get(UseCaseUtils.DOCUMENT_URI).size());
     assertEquals(
         "The following token cannot be on the same line as a DECLARATIVE token: MAMA",
-                result.getDiagnostics().get(UseCaseUtils.DOCUMENT_URI).get(1).getMessage());
+        result.getDiagnostics().get(UseCaseUtils.DOCUMENT_URI).get(1).getMessage());
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestOutlineTree.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestOutlineTree.java
@@ -14,10 +14,10 @@
  */
 package com.broadcom.lsp.cobol.usecases;
 
+import com.broadcom.lsp.cobol.core.semantics.outline.NodeType;
 import com.broadcom.lsp.cobol.positive.CobolText;
 import com.broadcom.lsp.cobol.service.delegates.validations.AnalysisResult;
 import com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils;
-import com.broadcom.lsp.cobol.core.semantics.outline.NodeType;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.junit.jupiter.api.Test;
 
@@ -27,115 +27,114 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.analyze;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** This test checks that Outline tree fot the program is constructed correctly */
-public class TestOutlineTree {
+class TestOutlineTree {
 
   private static final String TEXT =
-      "000010 COPY FOO.\n" +
-          "000020 Identification Division.\n" +
-          "000030 Program-id.  HELLO-WORLD       .\n" +
-          "000040\n" +
-          "000050 Data Division.\n" +
-          "000060 Working-Storage Section.\n" +
-          "000070     COPY BAR.\n" +
-          "000080     01 User-Num1 PIC 9(9).\n" +
-          "000090     01 User-Num2 PIC 9(9).\n" +
-          "000100     01 User-Address.\n" +
-          "000110     COPY BAZ.\n" +
-          "000120     05 User-City PIC X(5).\n" +
-          "000130     05 User-Country PIC X(5).\n" +
-          "000140     05 User-Index PIC 9(6).\n" +
-          "000150     05 User-Phone PIC 9(6).\n" +
-          "000160     01 FILLER.\n" +
-          "000170     03 FOO PIC X(5).\n" +
-          "000180\n" +
-          "000190 Procedure Division.\n" +
-          "000200    000-Main-Logic  .\n" +
-          "000210     Perform 100-Print-User.\n" +
-          "000220     Stop Run.\n" +
-          "000230\n" +
-          "000240  100-Print-User.\n" +
-          "000250     Move 123456789 To User-Num1.\n" +
-          "000260     Move User-Num1 To User-Num2.\n" +
-          "000270     Move 'Wenceslav Square 846/1' To User-Address.\n" +
-          "000280     Move 'Prague' To User-City.\n" +
-          "000290     Move 'CZ' To User-Country.\n" +
-          "000300     Move 11000 To User-Index.\n" +
-          "000310     Move 777123456 To User-Phone.\n" +
-          "000320\n" +
-          "000330     Display \"User-Num1     : \" User-Num1.\n" +
-          "000340     Display \"User-Num2     : \" User-Num2.\n" +
-          "000350     Display \"User-Address  : \" User-Address.\n" +
-          "000360     Display \"User-City     : \" User-City.\n" +
-          "000370     Display \"User-Country  : \" User-Country.\n" +
-          "000380     Display \"User-Index    : \" User-Index.\n" +
-          "000390     Display \"User-Phone    : \" User-Phone.\n" +
-          "000400\n" +
-          "000410 End program HELLO-WORLD.\n" +
-          "000420\n" +
-          "000430 IDENTIFICATION DIVISION.\n" +
-          "000440 PROGRAM-ID.            OUTLINE.\n" +
-          "000450 ENVIRONMENT DIVISION.\n" +
-          "000460 CONFIGURATION SECTION.\n" +
-          "000470 SPECIAL-NAMES.               C01 IS TOP-OF-PAGE.\n" +
-          "000480 INPUT-OUTPUT SECTION.\n" +
-          "000490 FILE-CONTROL.\n" +
-          "000500     SELECT TRANS-FILE-IN\n" +
-          "000510           ASSIGN TO SOMETHING-ELSE.\n" +
-          "000520 DATA DIVISION.\n" +
-          "000530 FILE SECTION.\n" +
-          "000540 FD  TRANS-FILE-IN\n" +
-          "000550     LABEL RECORDS ARE STANDARD\n" +
-          "000560     RECORDING MODE IS F\n" +
-          "000570     BLOCK CONTAINS 0 RECORDS\n" +
-          "000580     RECORD CONTAINS 113 CHARACTERS\n" +
-          "000590     DATA RECORD IS FILE-RECORD.\n" +
-          "000600 01  FILE-RECORD                             PIC X(113).\n" +
-          "000610 FD  TERMS-FILE\n" +
-          "000620     LABEL RECORDS ARE STANDARD\n" +
-          "000630     BLOCK CONTAINS 0 RECORDS\n" +
-          "000640     RECORD CONTAINS 71 CHARACTERS\n" +
-          "000650     DATA RECORD IS TERMS-RECORD.\n" +
-          "000660 01  TERMS-RECORD.\n" +
-          "000670     05  TERMS-KEY                           PIC 9(3).\n" +
-          "000680     05  FILLER                              PIC X(68).\n" +
-          "000690 WORKING-STORAGE SECTION.\n" +
-          "000700 77  COLR-DISPLAY    PIC 9(7).\n" +
-          "000710 01  CTLFILE-REC.\n" +
-          "000720         05  CTLFILE-PRIME               PIC  99V999.\n" +
-          "000730         05  CTLFILE-PAST-DUE-DIFF       PIC  99V999.\n" +
-          "000740 01  CTLFILE-REC-12 REDEFINES CTLFILE-REC.\n" +
-          "000750         05  CTLFILE-DB-DATE             PIC  9(6).\n" +
-          "000760         05  CTLFILE-ATB-DATE            PIC  9(6).\n" +
-          "000770         10  COST-RECORD-CODE                PIC 9.\n" +
-          "000780             88  HEADER    VALUE 1.\n" +
-          "000790             88  SUPPLR    VALUE 2.\n" +
-          "000800             88  WREHOUSE  VALUE 3.\n" +
-          "000810 LINKAGE SECTION.\n" +
-          "000820 01  LINK-PRM0.\n" +
-          "000830     05  PARM-LENGTH                        PIC S9(4) COMP.\n" +
-          "000840     05  PARM                               PIC X(8).\n" +
-          "000850 PROCEDURE DIVISION USING LINK-PRM0.\n" +
-          "000860 000-PROGRAM-DRIVER SECTION.\n" +
-          "000870     PERFORM 100-HOUSEKEEPING.\n" +
-          "000880     EJECT\n" +
-          "000890 100-HOUSEKEEPING SECTION.\n" +
-          "000900 110-OPEN-FILES.\n" +
-          "000910 112-READ-WAREHOUS-FILE.\n" +
-          "000920 199-EXIT.\n" +
-          "000930     EXIT.\n" +
-          "000940     EJECT\n";
+      "000010 COPY FOO.\n"
+          + "000020 Identification Division.\n"
+          + "000030 Program-id.  HELLO-WORLD       .\n"
+          + "000040\n"
+          + "000050 Data Division.\n"
+          + "000060 Working-Storage Section.\n"
+          + "000070     COPY BAR.\n"
+          + "000080     01 User-Num1 PIC 9(9).\n"
+          + "000090     01 User-Num2 PIC 9(9).\n"
+          + "000100     01 User-Address.\n"
+          + "000110     COPY BAZ.\n"
+          + "000120     05 User-City PIC X(5).\n"
+          + "000130     05 User-Country PIC X(5).\n"
+          + "000140     05 User-Index PIC 9(6).\n"
+          + "000150     05 User-Phone PIC 9(6).\n"
+          + "000160     01 FILLER.\n"
+          + "000170     03 FOO PIC X(5).\n"
+          + "000180\n"
+          + "000190 Procedure Division.\n"
+          + "000200    000-Main-Logic  .\n"
+          + "000210     Perform 100-Print-User.\n"
+          + "000220     Stop Run.\n"
+          + "000230\n"
+          + "000240  100-Print-User.\n"
+          + "000250     Move 123456789 To User-Num1.\n"
+          + "000260     Move User-Num1 To User-Num2.\n"
+          + "000270     Move 'Wenceslav Square 846/1' To User-Address.\n"
+          + "000280     Move 'Prague' To User-City.\n"
+          + "000290     Move 'CZ' To User-Country.\n"
+          + "000300     Move 11000 To User-Index.\n"
+          + "000310     Move 777123456 To User-Phone.\n"
+          + "000320\n"
+          + "000330     Display \"User-Num1     : \" User-Num1.\n"
+          + "000340     Display \"User-Num2     : \" User-Num2.\n"
+          + "000350     Display \"User-Address  : \" User-Address.\n"
+          + "000360     Display \"User-City     : \" User-City.\n"
+          + "000370     Display \"User-Country  : \" User-Country.\n"
+          + "000380     Display \"User-Index    : \" User-Index.\n"
+          + "000390     Display \"User-Phone    : \" User-Phone.\n"
+          + "000400\n"
+          + "000410 End program HELLO-WORLD.\n"
+          + "000420\n"
+          + "000430 IDENTIFICATION DIVISION.\n"
+          + "000440 PROGRAM-ID.            OUTLINE.\n"
+          + "000450 ENVIRONMENT DIVISION.\n"
+          + "000460 CONFIGURATION SECTION.\n"
+          + "000470 SPECIAL-NAMES.               C01 IS TOP-OF-PAGE.\n"
+          + "000480 INPUT-OUTPUT SECTION.\n"
+          + "000490 FILE-CONTROL.\n"
+          + "000500     SELECT TRANS-FILE-IN\n"
+          + "000510           ASSIGN TO SOMETHING-ELSE.\n"
+          + "000520 DATA DIVISION.\n"
+          + "000530 FILE SECTION.\n"
+          + "000540 FD  TRANS-FILE-IN\n"
+          + "000550     LABEL RECORDS ARE STANDARD\n"
+          + "000560     RECORDING MODE IS F\n"
+          + "000570     BLOCK CONTAINS 0 RECORDS\n"
+          + "000580     RECORD CONTAINS 113 CHARACTERS\n"
+          + "000590     DATA RECORD IS FILE-RECORD.\n"
+          + "000600 01  FILE-RECORD                             PIC X(113).\n"
+          + "000610 FD  TERMS-FILE\n"
+          + "000620     LABEL RECORDS ARE STANDARD\n"
+          + "000630     BLOCK CONTAINS 0 RECORDS\n"
+          + "000640     RECORD CONTAINS 71 CHARACTERS\n"
+          + "000650     DATA RECORD IS TERMS-RECORD.\n"
+          + "000660 01  TERMS-RECORD.\n"
+          + "000670     05  TERMS-KEY                           PIC 9(3).\n"
+          + "000680     05  FILLER                              PIC X(68).\n"
+          + "000690 WORKING-STORAGE SECTION.\n"
+          + "000700 77  COLR-DISPLAY    PIC 9(7).\n"
+          + "000710 01  CTLFILE-REC.\n"
+          + "000720         05  CTLFILE-PRIME               PIC  99V999.\n"
+          + "000730         05  CTLFILE-PAST-DUE-DIFF       PIC  99V999.\n"
+          + "000740 01  CTLFILE-REC-12 REDEFINES CTLFILE-REC.\n"
+          + "000750         05  CTLFILE-DB-DATE             PIC  9(6).\n"
+          + "000760         05  CTLFILE-ATB-DATE            PIC  9(6).\n"
+          + "000770         10  COST-RECORD-CODE                PIC 9.\n"
+          + "000780             88  HEADER    VALUE 1.\n"
+          + "000790             88  SUPPLR    VALUE 2.\n"
+          + "000800             88  WREHOUSE  VALUE 3.\n"
+          + "000810 LINKAGE SECTION.\n"
+          + "000820 01  LINK-PRM0.\n"
+          + "000830     05  PARM-LENGTH                        PIC S9(4) COMP.\n"
+          + "000840     05  PARM                               PIC X(8).\n"
+          + "000850 PROCEDURE DIVISION USING LINK-PRM0.\n"
+          + "000860 000-PROGRAM-DRIVER SECTION.\n"
+          + "000870     PERFORM 100-HOUSEKEEPING.\n"
+          + "000880     EJECT\n"
+          + "000890 100-HOUSEKEEPING SECTION.\n"
+          + "000900 110-OPEN-FILES.\n"
+          + "000910 112-READ-WAREHOUS-FILE.\n"
+          + "000920 199-EXIT.\n"
+          + "000930     EXIT.\n"
+          + "000940     EJECT\n";
 
   @Test
   void test() {
-    List<CobolText> copybooks = List.of(
-        new CobolText("FOO", ""),
-        new CobolText("BAR", "000100     01 HIDE-IT PIC 9(9)."),
-        new CobolText("BAZ", "")
-    );
+    List<CobolText> copybooks =
+        List.of(
+            new CobolText("FOO", ""),
+            new CobolText("BAR", "000100     01 HIDE-IT PIC 9(9)."),
+            new CobolText("BAZ", ""));
     List<DocumentSymbol> expectedNodes = getExpectedOutlineNodes();
     AnalysisResult result = UseCaseUtils.analyze(UseCaseUtils.DOCUMENT_URI, TEXT, copybooks);
     assertNodeListEquals(expectedNodes, result.getOutlineTree(), "/");
@@ -144,105 +143,148 @@ public class TestOutlineTree {
   private List<DocumentSymbol> getExpectedOutlineNodes() {
     return nested(
         node("COPY FOO", NodeType.COPYBOOK),
-        node("PROGRAM: HELLO-WORLD", NodeType.PROGRAM, nested(
-            node("IDENTIFICATION DIVISION", NodeType.DIVISION, nested(
-                node("PROGRAM-ID HELLO-WORLD", NodeType.PROGRAM_ID)
-            )),
-            node("DATA DIVISION", NodeType.DIVISION, nested(
-                node("WORKING-STORAGE SECTION", NodeType.SECTION, nested(
-                    node("COPY BAR", NodeType.COPYBOOK),
-                    node("User-Num1", NodeType.FIELD),
-                    node("User-Num2", NodeType.FIELD),
-                    node("User-Address", NodeType.STRUCT, nested(
-                        node("COPY BAZ", NodeType.COPYBOOK),
-                        node("User-City", NodeType.FIELD),
-                        node("User-Country", NodeType.FIELD),
-                        node("User-Index", NodeType.FIELD),
-                        node("User-Phone", NodeType.FIELD)
-                    )),
-                    node("FILLER", NodeType.STRUCT, nested(
-                        node("FOO", NodeType.FIELD)
-                    ))
-                ))
-            )),
-            node("PROCEDURE DIVISION", NodeType.DIVISION, nested(
-                node("000-Main-Logic", NodeType.PROCEDURE),
-                node("100-Print-User", NodeType.PROCEDURE)
-            ))
-        )),
-        node("PROGRAM: OUTLINE", NodeType.PROGRAM, nested(
-            node("IDENTIFICATION DIVISION", NodeType.DIVISION, nested(
-                node("PROGRAM-ID OUTLINE", NodeType.PROGRAM_ID)
-            )),
-            node("ENVIRONMENT DIVISION", NodeType.DIVISION, nested(
-                node("CONFIGURATION SECTION", NodeType.SECTION),
-                node("INPUT-OUTPUT SECTION", NodeType.SECTION, nested(
-                    node("TRANS-FILE-IN", NodeType.FILE)
-                ))
-            )),
-            node("DATA DIVISION", NodeType.DIVISION, nested(
-                node("FILE SECTION", NodeType.SECTION, nested(
-                    node("TRANS-FILE-IN", NodeType.FILE, nested(
-                        node("FILE-RECORD", NodeType.FIELD)
-                    )),
-                    node("TERMS-FILE", NodeType.FILE, nested(
-                        node("TERMS-RECORD", NodeType.STRUCT, nested(
-                            node("TERMS-KEY", NodeType.FIELD),
-                            node("FILLER", NodeType.FIELD)
-                        ))
-                    ))
-                )),
-                node("WORKING-STORAGE SECTION", NodeType.SECTION, nested(
-                    node("COLR-DISPLAY", NodeType.FIELD),
-                    node("CTLFILE-REC", NodeType.STRUCT, nested(
-                        node("CTLFILE-PRIME", NodeType.FIELD),
-                        node("CTLFILE-PAST-DUE-DIFF", NodeType.FIELD)
-                    )),
-                    node("CTLFILE-REC-12", NodeType.REDEFINES, nested(
-                        node("CTLFILE-DB-DATE", NodeType.FIELD),
-                        node("CTLFILE-ATB-DATE", NodeType.FIELD),
-                        node("COST-RECORD-CODE", NodeType.FIELD, nested(
-                            node("HEADER", NodeType.FIELD_88),
-                            node("SUPPLR", NodeType.FIELD_88),
-                            node("WREHOUSE", NodeType.FIELD_88)
-                        ))
-                    ))
-                )),
-                node("LINKAGE SECTION", NodeType.SECTION, nested(
-                    node("LINK-PRM0", NodeType.STRUCT, nested(
-                        node("PARM-LENGTH", NodeType.FIELD),
-                        node("PARM", NodeType.FIELD)
-                    ))
-                ))
-            )),
-            node("PROCEDURE DIVISION", NodeType.DIVISION, nested(
-                node("000-PROGRAM-DRIVER", NodeType.PROCEDURE_SECTION),
-                node("100-HOUSEKEEPING", NodeType.PROCEDURE_SECTION, nested(
-                    node("110-OPEN-FILES", NodeType.PROCEDURE),
-                    node("112-READ-WAREHOUS-FILE", NodeType.PROCEDURE),
-                    node("199-EXIT", NodeType.PROCEDURE)
-                ))
-            ))
-        ))
-    );
+        node(
+            "PROGRAM: HELLO-WORLD",
+            NodeType.PROGRAM,
+            nested(
+                node(
+                    "IDENTIFICATION DIVISION",
+                    NodeType.DIVISION,
+                    nested(node("PROGRAM-ID HELLO-WORLD", NodeType.PROGRAM_ID))),
+                node(
+                    "DATA DIVISION",
+                    NodeType.DIVISION,
+                    nested(
+                        node(
+                            "WORKING-STORAGE SECTION",
+                            NodeType.SECTION,
+                            nested(
+                                node("COPY BAR", NodeType.COPYBOOK),
+                                node("User-Num1", NodeType.FIELD),
+                                node("User-Num2", NodeType.FIELD),
+                                node(
+                                    "User-Address",
+                                    NodeType.STRUCT,
+                                    nested(
+                                        node("COPY BAZ", NodeType.COPYBOOK),
+                                        node("User-City", NodeType.FIELD),
+                                        node("User-Country", NodeType.FIELD),
+                                        node("User-Index", NodeType.FIELD),
+                                        node("User-Phone", NodeType.FIELD))),
+                                node(
+                                    "FILLER",
+                                    NodeType.STRUCT,
+                                    nested(node("FOO", NodeType.FIELD))))))),
+                node(
+                    "PROCEDURE DIVISION",
+                    NodeType.DIVISION,
+                    nested(
+                        node("000-Main-Logic", NodeType.PROCEDURE),
+                        node("100-Print-User", NodeType.PROCEDURE))))),
+        node(
+            "PROGRAM: OUTLINE",
+            NodeType.PROGRAM,
+            nested(
+                node(
+                    "IDENTIFICATION DIVISION",
+                    NodeType.DIVISION,
+                    nested(node("PROGRAM-ID OUTLINE", NodeType.PROGRAM_ID))),
+                node(
+                    "ENVIRONMENT DIVISION",
+                    NodeType.DIVISION,
+                    nested(
+                        node("CONFIGURATION SECTION", NodeType.SECTION),
+                        node(
+                            "INPUT-OUTPUT SECTION",
+                            NodeType.SECTION,
+                            nested(node("TRANS-FILE-IN", NodeType.FILE))))),
+                node(
+                    "DATA DIVISION",
+                    NodeType.DIVISION,
+                    nested(
+                        node(
+                            "FILE SECTION",
+                            NodeType.SECTION,
+                            nested(
+                                node(
+                                    "TRANS-FILE-IN",
+                                    NodeType.FILE,
+                                    nested(node("FILE-RECORD", NodeType.FIELD))),
+                                node(
+                                    "TERMS-FILE",
+                                    NodeType.FILE,
+                                    nested(
+                                        node(
+                                            "TERMS-RECORD",
+                                            NodeType.STRUCT,
+                                            nested(
+                                                node("TERMS-KEY", NodeType.FIELD),
+                                                node("FILLER", NodeType.FIELD))))))),
+                        node(
+                            "WORKING-STORAGE SECTION",
+                            NodeType.SECTION,
+                            nested(
+                                node("COLR-DISPLAY", NodeType.FIELD),
+                                node(
+                                    "CTLFILE-REC",
+                                    NodeType.STRUCT,
+                                    nested(
+                                        node("CTLFILE-PRIME", NodeType.FIELD),
+                                        node("CTLFILE-PAST-DUE-DIFF", NodeType.FIELD))),
+                                node(
+                                    "CTLFILE-REC-12",
+                                    NodeType.REDEFINES,
+                                    nested(
+                                        node("CTLFILE-DB-DATE", NodeType.FIELD),
+                                        node("CTLFILE-ATB-DATE", NodeType.FIELD),
+                                        node(
+                                            "COST-RECORD-CODE",
+                                            NodeType.FIELD,
+                                            nested(
+                                                node("HEADER", NodeType.FIELD_88),
+                                                node("SUPPLR", NodeType.FIELD_88),
+                                                node("WREHOUSE", NodeType.FIELD_88))))))),
+                        node(
+                            "LINKAGE SECTION",
+                            NodeType.SECTION,
+                            nested(
+                                node(
+                                    "LINK-PRM0",
+                                    NodeType.STRUCT,
+                                    nested(
+                                        node("PARM-LENGTH", NodeType.FIELD),
+                                        node("PARM", NodeType.FIELD))))))),
+                node(
+                    "PROCEDURE DIVISION",
+                    NodeType.DIVISION,
+                    nested(
+                        node("000-PROGRAM-DRIVER", NodeType.PROCEDURE_SECTION),
+                        node(
+                            "100-HOUSEKEEPING",
+                            NodeType.PROCEDURE_SECTION,
+                            nested(
+                                node("110-OPEN-FILES", NodeType.PROCEDURE),
+                                node("112-READ-WAREHOUS-FILE", NodeType.PROCEDURE),
+                                node("199-EXIT", NodeType.PROCEDURE))))))));
   }
 
-  private void assertNodeListEquals(List<DocumentSymbol> expected, List<DocumentSymbol> actual, String level) {
+  private void assertNodeListEquals(
+      List<DocumentSymbol> expected, List<DocumentSymbol> actual, String level) {
     Map<String, DocumentSymbol> expectedMap = toMap(expected);
     Map<String, DocumentSymbol> actualMap = toMap(actual);
-    assertEquals("Elements on level " + level, expectedMap.keySet(), actualMap.keySet());
-    for (DocumentSymbol expectedNode: expectedMap.values()) {
+    assertEquals(expectedMap.keySet(), actualMap.keySet(), "Elements on level " + level);
+    for (DocumentSymbol expectedNode : expectedMap.values()) {
       assertNodeEquals(expectedNode, actualMap.get(expectedNode.getName()), level);
     }
   }
 
   /**
-   * The method compares only node types and nested nodes.
-   * Two outline nodes with different ranges will be equal.
+   * The method compares only node types and nested nodes. Two outline nodes with different ranges
+   * will be equal.
    */
   private void assertNodeEquals(DocumentSymbol expected, DocumentSymbol actual, String oldLevel) {
     String level = oldLevel + '/' + expected.getName();
-    assertEquals("Node types for " + level, expected.getKind(), actual.getKind());
+    assertEquals(expected.getKind(), actual.getKind(), "Node types for " + level);
     assertNodeListEquals(expected.getChildren(), actual.getChildren(), level);
   }
 


### PR DESCRIPTION
To avoid accidental use of the outdated infrastructure.

@grianbrcom 
@asatklichov 