### PR TITLE
Move unsupported files notification into problems console #173

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -169,6 +169,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>concurrentunit</artifactId>
             <version>${concurrentunit.version}</version>

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -43,6 +43,12 @@ import static org.eclipse.lsp4j.MessageType.Info;
  */
 @Slf4j
 public class ServerCommunications implements Communications {
+
+  static final String CANNOT_FIND_LANGUAGE_ENGINE = "Cannot find a language engine for the given language ID: ";
+  static final String SYNTAX_ANALYSIS_IN_PROGRESS = ": Syntax analysis in progress";
+  static final String NO_SYNTAX_ERRORS = "No syntax errors detected in ";
+  static final String EXTENSION_UNSUPPORTED = "The given document extension is unsupported: ";
+
   private Provider<LanguageClient> provider;
   private FileSystemService files;
 
@@ -66,7 +72,7 @@ public class ServerCommunications implements Communications {
     runAsync(
         () ->
             showMessage(
-                Error, "Cannot find a language engine for the given language ID: " + languageType));
+                Error, CANNOT_FIND_LANGUAGE_ENGINE + languageType));
   }
 
   /**
@@ -82,7 +88,7 @@ public class ServerCommunications implements Communications {
     executor.schedule(
         () -> {
           if (uriInProgress.remove(decodedUri)) {
-            showMessage(Info, retrieveFileName(decodedUri) + ": Syntax analysis in progress");
+            showMessage(Info, retrieveFileName(decodedUri) + SYNTAX_ANALYSIS_IN_PROGRESS);
           }
         },
         3,
@@ -99,7 +105,7 @@ public class ServerCommunications implements Communications {
     runAsync(
         () ->
             logMessage(
-                Info, "No syntax errors detected in " + retrieveFileName(files.decodeURI(uri))));
+                Info, NO_SYNTAX_ERRORS + retrieveFileName(files.decodeURI(uri))));
   }
 
   /**
@@ -109,7 +115,7 @@ public class ServerCommunications implements Communications {
    */
   @Override
   public void notifyThatExtensionIsUnsupported(String extension) {
-    runAsync(() -> showMessage(Error, "The given document extension is unsupported: " + extension));
+    runAsync(() -> logMessage(Error, EXTENSION_UNSUPPORTED + extension));
   }
 
   /**

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -146,9 +146,9 @@ class CobolTextDocumentServiceTest extends ConfigurableTest {
     service.didOpen(
         new DidOpenTextDocumentParams(
             new TextDocumentItem(CPY_DOCUMENT_URI, LANGUAGE, 1, TEXT_EXAMPLE)));
-    UseCaseUtils.await(() -> !client.getMessagesToShow().isEmpty());
+    UseCaseUtils.await(() -> !client.getMessagesToLog().isEmpty());
     assertTrue(
-        client.getMessagesToShow().stream()
+        client.getMessagesToLog().stream()
             .map((Function<MessageParams, Object>) MessageParams::getMessage)
             .anyMatch(
                 it ->


### PR DESCRIPTION
- Move unsupported files notification into problems console instead of logging
- Add unit tests for uncovered methods
