### PR TITLE
Add an unwrap method to ResultWithErrors

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/model/ResultWithErrors.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/model/ResultWithErrors.java
@@ -19,6 +19,7 @@ import lombok.Value;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * This value class represents a processing result of any type that may contain syntax errors.
@@ -29,4 +30,16 @@ import java.util.List;
 public class ResultWithErrors<T> {
   @Nonnull T result;
   @Nonnull List<SyntaxError> errors;
+
+  /**
+   * Consume the found errors and return the result. May be used as <code>
+   *  Type variable = result.unpack(syntaxErrorList::addAll);</code>
+   *
+   * @param errorsConsumer - a Consumer to accept errors
+   * @return - the processing result
+   */
+  public T unwrap(Consumer<List<SyntaxError>> errorsConsumer) {
+    errorsConsumer.accept(errors);
+    return result;
+  }
 }

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorListenerImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorListenerImpl.java
@@ -287,7 +287,8 @@ public class GrammarPreprocessorListenerImpl extends CobolPreprocessorBaseListen
       return emptyModel(copybookName);
     }
 
-    CopybookModel copybook = copybookService.resolve(copybookName, documentUri, copybookProcessingMode);
+    CopybookModel copybook =
+        copybookService.resolve(copybookName, documentUri, copybookProcessingMode);
 
     if (copybook.getContent() == null) {
       reportMissingCopybooks(copybookName, locality);
@@ -304,13 +305,12 @@ public class GrammarPreprocessorListenerImpl extends CobolPreprocessorBaseListen
   private ExtendedDocument processCopybook(
       String copybookName, String uri, String copybookId, String content, Locality locality) {
     copybookStack.push(new CopybookUsage(copybookName, copybookId, locality));
-    ResultWithErrors<ExtendedDocument> result =
-        preprocessor.process(uri, content, copybookStack, copybookProcessingMode);
+    ExtendedDocument result =
+        preprocessor
+            .process(uri, content, copybookStack, copybookProcessingMode)
+            .unwrap(errors::addAll);
     copybookStack.pop();
-
-    errors.addAll(result.getErrors());
-
-    return result.getResult();
+    return result;
   }
 
   private CopybookModel emptyModel(String copybookName) {

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/CobolLineReaderImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/CobolLineReaderImpl.java
@@ -87,12 +87,9 @@ public class CobolLineReaderImpl implements CobolLineReader {
 
       while (scanner.hasNextLine()) {
         currentLine = scanner.nextLine();
-
-        ResultWithErrors<CobolLine> output =
-            parseLine(delegate.apply(currentLine), documentURI, lineNumber);
-
-        CobolLine currentCobolLine = output.getResult();
-        accumulatedErrors.addAll(output.getErrors());
+        CobolLine currentCobolLine =
+            parseLine(delegate.apply(currentLine), documentURI, lineNumber)
+                .unwrap(accumulatedErrors::addAll);
 
         currentCobolLine.setPredecessor(lastCobolLine);
         result.add(currentCobolLine);
@@ -116,10 +113,10 @@ public class CobolLineReaderImpl implements CobolLineReader {
       cobolLine.setSequenceArea(matcher.group("sequence"));
       String indicatorArea = matcher.group("indicator");
       if (!indicatorArea.isEmpty()) {
-        ResultWithErrors<CobolLineTypeEnum> type = determineType(indicatorArea, uri, lineNumber);
+        CobolLineTypeEnum type =
+            determineType(indicatorArea, uri, lineNumber).unwrap(errors::addAll);
         cobolLine.setIndicatorArea(indicatorArea);
-        cobolLine.setType(type.getResult());
-        errors.addAll(type.getErrors());
+        cobolLine.setType(type);
       }
       cobolLine.setContentAreaA(matcher.group("contentA"));
       cobolLine.setContentAreaB(matcher.group("contentB"));


### PR DESCRIPTION
Add a method that will apply some operation to the errors and return the result with parametrized type to ResultWithErrors class in order to inline method calls that return values of that type.