### PR TITLE
Support Termination Requests #590

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/LanguageClientServiceTest.spec.ts
@@ -62,10 +62,16 @@ describe("LanguageClientService negative scenario.", () => {
 });
 
 const SERVER_STARTED_MSG = "server started";
+const SERVER_STOPPED_MSG = "server stopped";
 describe("LanguageClientService positive scenario", () => {
-    languageClientService = new LanguageClientService(middleware);
-    new JavaCheck().isJavaInstalled = jest.fn().mockResolvedValue(true);
-    fs.existsSync = jest.fn().mockReturnValue(true);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        languageClientService = new LanguageClientService(middleware);
+        new JavaCheck().isJavaInstalled = jest.fn().mockResolvedValue(true);
+        fs.existsSync = jest.fn().mockReturnValue(true);
+    });
+
     test("Test LanguageClientService checkPrerequisites passes", async () => {
         expect(async () => await languageClientService.checkPrerequisites()).not.toThrowError();
     });
@@ -88,8 +94,7 @@ describe("LanguageClientService positive scenario", () => {
         });
     });
 
-    test("Test LanguageClientService starts language server is started when port is provided", () => {
-        jest.clearAllMocks();
+    test("LanguageClientService starts the language server when port is provided", () => {
         new JavaCheck().isJavaInstalled = jest.fn().mockResolvedValue(true);
         vscode.workspace.getConfiguration(expect.any(String)).get = jest.fn().mockReturnValue(9999);
         LanguageClient.prototype.start = jest.fn().mockReturnValue(SERVER_STARTED_MSG);
@@ -103,5 +108,13 @@ describe("LanguageClientService positive scenario", () => {
                 },
             },
         });
+    });
+
+    test("Test LanguageClientService fire a stop() command on LanguageClient", async () => {
+        LanguageClient.prototype.stop = jest.fn().mockReturnValue(SERVER_STOPPED_MSG);
+        // start the server, before shutdown.
+        languageClientService.start();
+        const returnedValue = await languageClientService.stop();
+        expect(returnedValue).toBe(SERVER_STOPPED_MSG);
     });
 });

--- a/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/LanguageClientService.ts
@@ -29,6 +29,7 @@ import {Middleware} from "./Middleware";
 
 export class LanguageClientService {
     private readonly jarPath: string;
+    private languageClient: LanguageClient;
 
     constructor(private middleware: Middleware) {
         const ext = vscode.extensions.getExtension("BroadcomMFD.cobol-language-support");
@@ -43,11 +44,23 @@ export class LanguageClientService {
     }
 
     public start(): vscode.Disposable {
-        const languageClient = new LanguageClient(LANGUAGE_ID,
-            "LSP extension for " + LANGUAGE_ID + " language",
-            this.createServerOptions(this.jarPath),
-            this.createClientOptions());
-        return languageClient.start();
+        return this.getLanguageClient().start();
+    }
+
+    public stop(): Thenable<void> {
+        if (this.languageClient) {
+            return Promise.resolve(this.getLanguageClient().stop());
+        }
+    }
+
+    private getLanguageClient() {
+        if (!this.languageClient) {
+            this.languageClient = new LanguageClient(LANGUAGE_ID,
+                "LSP extension for " + LANGUAGE_ID + " language",
+                this.createServerOptions(this.jarPath),
+                this.createClientOptions());
+        }
+        return this.languageClient;
     }
 
     private getLspPort(): number | undefined {

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/CheckServerShutdownState.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/CheckServerShutdownState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to handle LSP server shutdown state.
+ * This annotation only work on a class of type {@link DisposableService}.
+ * <p>annotation limitation:
+ * 1. Classes must be public or package-private.
+ * 2. Classes must be non-final
+ * 3. Methods must be public, package-private or protected
+ * 4. Methods must be non-final
+ * 5. It is not possible to use on instances that aren't constructed by Guice.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CheckServerShutdownState {}

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/DisposableService.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/DisposableService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+/**
+ * {@link DisposableService} is a marker interface to mark all services which are disposable after a
+ * shutdown call on LSP server.
+ *
+ * <p>Use {@link com.broadcom.lsp.cobol.core.annotation.CheckServerShutdownState} annotation on each
+ * service methods to mark them disposed after a shutdown call.
+ */
+public interface DisposableService {}

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/HandleShutdownState.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/HandleShutdownState.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+import com.broadcom.lsp.cobol.service.DisposableLanguageServer;
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Intercept method call annotated with {@link CheckServerShutdownState}. Checks if server is in
+ * shutdown state, if yes, it always return SHUTDOWN_RESPONSE.
+ */
+@Slf4j
+public class HandleShutdownState implements MethodInterceptor {
+  private static final String SHUTDOWN_RESPONSE = "InvalidRequest";
+  private LanguageServer server;
+
+  @Inject
+  public void setServer(LanguageServer server) {
+    this.server = server;
+  }
+
+  /**
+   * Check if server is in shutdown state, if yes, it always return SHUTDOWN_RESPONSE. Else,
+   * proceeds with actual method call.
+   *
+   * @param invocation {@link MethodInvocation}
+   * @return a fixed string (SHUTDOWN_RESPONSE) if server is in shutdown state. Else, proceeds with
+   *     actual method call.
+   * @throws Throwable
+   */
+  @Override
+  public Object invoke(MethodInvocation invocation) throws Throwable {
+    if (server instanceof DisposableLanguageServer) {
+      DisposableLanguageServer languageServer = (DisposableLanguageServer) server;
+      if (languageServer.getExitCode() == DisposableLanguageServer.SHUTDOWN_EXIT_CODE) {
+        LOG.info(invocation.getMethod().getName() + " invoked after shutdown");
+        return CompletableFuture.completedFuture(SHUTDOWN_RESPONSE);
+      }
+    }
+    return invocation.proceed();
+  }
+}

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/NonSyntheticMethodMatcher.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/annotation/NonSyntheticMethodMatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+import com.google.inject.matcher.AbstractMatcher;
+
+import java.lang.reflect.Method;
+
+/**
+ * Custom {@link com.google.inject.matcher.Matcher} to identify any synthetic method and returns
+ * false if the method is synthetic
+ *
+ * <p>Java Language Specification (JLS 13.1.7): Any constructs introduced by a Java compiler that do
+ * not have a corresponding construct in the source code must be marked as synthetic, except for
+ * default constructors, the class initialization method, and the values and valueOf methods of the
+ * Enum class.
+ *
+ * <p>Guice dynamically creates a subclass that applies interceptors by overriding methods. And may
+ * introduce some synthetic methods.
+ */
+public class NonSyntheticMethodMatcher extends AbstractMatcher<Method> {
+
+  /**
+   * match any synthetic method and returns false if the method is synthetic
+   *
+   * @param method
+   * @return true if method is non-synthetic and false otherwise
+   */
+  @Override
+  public boolean matches(Method method) {
+    return !method.isSynthetic();
+  }
+}

--- a/server/src/main/java/com/broadcom/lsp/cobol/domain/modules/ServiceModule.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/domain/modules/ServiceModule.java
@@ -14,9 +14,7 @@
  */
 package com.broadcom.lsp.cobol.domain.modules;
 
-import com.broadcom.lsp.cobol.core.annotation.CheckThreadInterruption;
-import com.broadcom.lsp.cobol.core.annotation.HandleThreadInterruption;
-import com.broadcom.lsp.cobol.core.annotation.ThreadInterruptAspect;
+import com.broadcom.lsp.cobol.core.annotation.*;
 import com.broadcom.lsp.cobol.service.*;
 import com.broadcom.lsp.cobol.service.delegates.actions.CodeActionProvider;
 import com.broadcom.lsp.cobol.service.delegates.actions.CodeActions;
@@ -73,6 +71,13 @@ public class ServiceModule extends AbstractModule {
         Matchers.subclassesOf(ThreadInterruptAspect.class),
         Matchers.annotatedWith(CheckThreadInterruption.class),
         new HandleThreadInterruption());
+
+    HandleShutdownState handleShutdownState = new HandleShutdownState();
+    requestInjection(handleShutdownState);
+    bindInterceptor(
+        Matchers.subclassesOf(DisposableService.class),
+            (new NonSyntheticMethodMatcher()).and(Matchers.annotatedWith(CheckServerShutdownState.class)),
+        handleShutdownState);
   }
 
   private void bindFormations() {

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/CobolWorkspaceServiceImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/CobolWorkspaceServiceImpl.java
@@ -14,6 +14,8 @@
  */
 package com.broadcom.lsp.cobol.service;
 
+import com.broadcom.lsp.cobol.core.annotation.CheckServerShutdownState;
+import com.broadcom.lsp.cobol.core.annotation.DisposableService;
 import com.broadcom.lsp.cobol.core.messages.LocaleStore;
 import com.broadcom.lsp.cobol.core.messages.LogLevelUtils;
 import com.broadcom.lsp.cobol.core.model.ErrorCode;
@@ -46,7 +48,7 @@ import static java.util.stream.Collectors.toList;
  */
 @Slf4j
 @Singleton
-public class CobolWorkspaceServiceImpl implements WorkspaceService {
+public class CobolWorkspaceServiceImpl implements WorkspaceService, DisposableService {
   private DataBusBroker dataBus;
   private SettingsService settingsService;
   private WatcherService watchingService;
@@ -77,6 +79,7 @@ public class CobolWorkspaceServiceImpl implements WorkspaceService {
    */
   @NonNull
   @Override
+  @CheckServerShutdownState
   public CompletableFuture<Object> executeCommand(@NonNull ExecuteCommandParams params) {
     runAsync(executeCopybookFix(params)).whenComplete(reportExceptionIfFound(params));
 
@@ -99,6 +102,7 @@ public class CobolWorkspaceServiceImpl implements WorkspaceService {
    * @param params - LSPSpecification -> The actual changed settings; Actually -> null all the time.
    */
   @Override
+  @CheckServerShutdownState
   public void didChangeConfiguration(DidChangeConfigurationParams params) {
     settingsService
         .getConfiguration(LOCAL_PATHS.label)
@@ -130,6 +134,7 @@ public class CobolWorkspaceServiceImpl implements WorkspaceService {
    *     sent from the client to the server.
    */
   @Override
+  @CheckServerShutdownState
   public void didChangeWatchedFiles(@NonNull DidChangeWatchedFilesParams params) {
     rerunAnalysis(false);
   }

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/DisposableLanguageServer.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/DisposableLanguageServer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.service;
+
+/**
+ * Contract for the server which can have multiple running state. And an exit code would determine
+ * the actual status of server.
+ */
+public interface DisposableLanguageServer {
+  int SHUTDOWN_EXIT_CODE = 0;
+
+  /**
+   * Return an int, which determine the current state of a server.
+   *
+   * @return int
+   */
+  int getExitCode();
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/ConfigurableTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/ConfigurableTest.java
@@ -18,18 +18,36 @@ import com.broadcom.lsp.cobol.domain.modules.DatabusModule;
 import com.broadcom.lsp.cobol.domain.modules.EngineModule;
 import com.broadcom.lsp.cobol.positive.CobolTextRegistry;
 import com.broadcom.lsp.cobol.positive.FolderTextRegistry;
+import com.broadcom.lsp.cobol.service.utils.CustomThreadPoolExecutor;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
+
+import java.util.concurrent.Executors;
 
 import static java.lang.System.getProperty;
 import static java.util.Optional.ofNullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class ConfigurableTest {
   protected static final String PATH_TO_TEST_RESOURCES = "filesToTestPath";
   protected Injector injector =
       Guice.createInjector(new TestModule(), new EngineModule(), new DatabusModule());
+  private CustomThreadPoolExecutor customExecutor;
+
+  @BeforeAll
+  void init() {
+    customExecutor = mock(CustomThreadPoolExecutor.class);
+    when(customExecutor.getThreadPoolExecutor()).thenReturn(Executors.newFixedThreadPool(3));
+    when(customExecutor.getScheduledThreadPoolExecutor()).thenReturn(Executors.newScheduledThreadPool(3));
+  }
+
+  protected CustomThreadPoolExecutor getCustomExecutor() {
+    return customExecutor;
+  }
 
   /**
    * Retrieve {@link CobolTextRegistry} using file-based implementation.

--- a/server/src/test/java/com/broadcom/lsp/cobol/LangServerBootstrapTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/LangServerBootstrapTest.java
@@ -17,8 +17,7 @@ package com.broadcom.lsp.cobol;
 
 import com.broadcom.lsp.cobol.service.CobolLanguageServer;
 import com.broadcom.lsp.cobol.service.mocks.TestLanguageServer;
-import com.broadcom.lsp.cobol.service.utils.CustomThreadPoolExecutor;
-import com.broadcom.lsp.cobol.service.utils.CustomThreadPoolExecutorService;
+import com.broadcom.lsp.cobol.service.providers.ClientProvider;
 import com.google.inject.Injector;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -40,12 +39,10 @@ class LangServerBootstrapTest {
   private static final String PIPES = "pipeEnabled";
 
   private LanguageServer server;
-  private CustomThreadPoolExecutor customExecutor;
 
   @BeforeEach
   void setUp() {
     server = new TestLanguageServer();
-    customExecutor = new CustomThreadPoolExecutorService(4, 5, 60, 3);
   }
 
   @Test
@@ -54,12 +51,12 @@ class LangServerBootstrapTest {
 
     // Bound class in Service module
     CobolLanguageServer server = injector.getInstance(CobolLanguageServer.class);
-    CustomThreadPoolExecutor customExecutor = injector.getInstance(CustomThreadPoolExecutor.class);
+    ClientProvider clientProvider = injector.getInstance(ClientProvider.class);
     // Bound constant in Databus module
     Integer cacheSize = injector.getInstance(get(Integer.class, named("CACHE-MAX-SIZE")));
 
     assertNotNull(server);
-    assertNotNull(customExecutor);
+    assertNotNull(clientProvider);
     assertNotNull(cacheSize);
   }
 
@@ -93,9 +90,7 @@ class LangServerBootstrapTest {
                 fail(e.getMessage());
               }
             });
-    Launcher<LanguageClient> launcher =
-        LangServerBootstrap.createServerLauncherWithSocket(
-            server, customExecutor.getThreadPoolExecutor());
+    Launcher<LanguageClient> launcher = LangServerBootstrap.createServerLauncherWithSocket(server);
 
     assertNotNull(launcher.getRemoteProxy());
   }
@@ -103,8 +98,7 @@ class LangServerBootstrapTest {
   @Test
   void createServerLauncher() {
     Launcher<LanguageClient> launcher =
-        LangServerBootstrap.createServerLauncher(
-            server, System.in, System.out, customExecutor.getThreadPoolExecutor());
+        LangServerBootstrap.createServerLauncher(server, System.in, System.out);
 
     assertNotNull(launcher.getRemoteProxy());
   }
@@ -112,8 +106,7 @@ class LangServerBootstrapTest {
   @Test
   void startServer() throws IOException {
     Launcher<LanguageClient> launcher =
-        LangServerBootstrap.launchServer(
-            new String[] {PIPES}, server, customExecutor.getThreadPoolExecutor());
+        LangServerBootstrap.launchServer(new String[] {PIPES}, server);
     assertNotNull(launcher.getRemoteProxy());
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/HandleShutdownStateTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/HandleShutdownStateTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+import com.broadcom.lsp.cobol.service.DisposableLanguageServer;
+import org.aopalliance.intercept.MethodInvocation;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/** Tests {@link HandleShutdownState} */
+class HandleShutdownStateTest {
+
+  @Test
+  void whenServerShutdown_thenInvokeReturnSameMessage() throws Throwable {
+    HandleShutdownState handleShutdownState = new HandleShutdownState();
+    LanguageServer server =
+        mock(LanguageServer.class, withSettings().extraInterfaces(DisposableLanguageServer.class));
+    handleShutdownState.setServer(server);
+    when(((DisposableLanguageServer) server).getExitCode()).thenReturn(0);
+    MethodInvocation methodInvocation = mock(MethodInvocation.class);
+    Method mockMethod = this.getClass().getMethods()[0];
+    when(methodInvocation.getMethod()).thenReturn(mockMethod);
+    String response =
+        (String) ((CompletableFuture) handleShutdownState.invoke(methodInvocation)).get();
+    assertEquals("InvalidRequest", response);
+  }
+
+  @Test
+  void whenNotServerShutdown_thenInvokeProceedsToActualMethodCall() throws Throwable {
+    HandleShutdownState handleShutdownState = new HandleShutdownState();
+    LanguageServer server =
+        mock(LanguageServer.class, withSettings().extraInterfaces(DisposableLanguageServer.class));
+    handleShutdownState.setServer(server);
+    when(((DisposableLanguageServer) server).getExitCode()).thenReturn(1);
+    MethodInvocation methodInvocation = mock(MethodInvocation.class);
+    handleShutdownState.invoke(methodInvocation);
+    verify(methodInvocation).proceed();
+  }
+
+  @Test
+  void whenServerNotInstanceOfDisposableLanguageServer_thenInvokeProceedsToActualMethodCall()
+      throws Throwable {
+    HandleShutdownState handleShutdownState = new HandleShutdownState();
+    LanguageServer server = mock(LanguageServer.class);
+    handleShutdownState.setServer(server);
+    MethodInvocation methodInvocation = mock(MethodInvocation.class);
+    handleShutdownState.invoke(methodInvocation);
+    verify(methodInvocation).proceed();
+  }
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/NonSyntheticMethodMatcherTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/NonSyntheticMethodMatcherTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.annotation;
+
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test {@link NonSyntheticMethodMatcher} to check if {@link
+ * NonSyntheticMethodMatcher#matches(Method)} works as expected.
+ */
+class NonSyntheticMethodMatcherTest {
+
+  @Test
+  void whenMethodIsSynthetic_thenReturnFalse() {
+    NonSyntheticMethodMatcher nonSyntheticMethodMatcher = new NonSyntheticMethodMatcher();
+    Method[] methods = NonSyntheticMethodMatcher.class.getDeclaredMethods();
+    for (Method m : methods) {
+      if (m.isSynthetic()) assertFalse(nonSyntheticMethodMatcher.matches(m));
+    }
+  }
+
+  @Test
+  void whenMethodIsNotSynthetic_thenReturnTrue() {
+    NonSyntheticMethodMatcher nonSyntheticMethodMatcher = new NonSyntheticMethodMatcher();
+    Method[] methods = NonSyntheticMethodMatcher.class.getDeclaredMethods();
+    for (Method m : methods) {
+      if (!m.isSynthetic()) assertTrue(nonSyntheticMethodMatcher.matches(m));
+    }
+  }
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/DocumentExtensionTests.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/DocumentExtensionTests.java
@@ -15,6 +15,7 @@
 
 package com.broadcom.lsp.cobol.service;
 
+import com.broadcom.lsp.cobol.ConfigurableTest;
 import com.broadcom.lsp.cobol.domain.databus.api.DataBusBroker;
 import com.broadcom.lsp.cobol.service.delegates.communications.Communications;
 import com.broadcom.lsp.cobol.service.delegates.validations.AnalysisResult;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.*;
  * extensions. If an extension of a document is unsupported (i.e. not "cob", "cbl" or "cobol"
  * ignoring case) then the according to notification should be sent.
  */
-class DocumentExtensionTests {
+class DocumentExtensionTests extends ConfigurableTest {
   private static final String DOCUMENT_URI_BEGINNING = "file:///c%3A/workspace/document.";
   private static final String TEXT = "";
   private static final String INCORRECT_TEXT_EXAMPLE = "       IDENTIFICATION DIVISIONs.";
@@ -98,6 +99,7 @@ class DocumentExtensionTests {
             .communications(communications)
             .engine(engine)
             .dataBus(broker)
+            .executors(getCustomExecutor())
             .build();
     service.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, extension, 0, TEXT)));
   }
@@ -111,6 +113,7 @@ class DocumentExtensionTests {
             .communications(communications)
             .engine(engine)
             .dataBus(broker)
+            .executors(getCustomExecutor())
             .build();
     service.didChange(
         new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(uri, 0), textEdits));

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/mocks/TestLanguageServer.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/mocks/TestLanguageServer.java
@@ -14,7 +14,9 @@
  */
 package com.broadcom.lsp.cobol.service.mocks;
 
+import com.broadcom.lsp.cobol.service.DisposableLanguageServer;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -24,7 +26,9 @@ import org.eclipse.lsp4j.services.WorkspaceService;
 import java.util.concurrent.CompletableFuture;
 
 /** Mock implementation of language server. Only for testing purposes. */
-public class TestLanguageServer implements LanguageServer {
+@Singleton
+public class TestLanguageServer implements LanguageServer, DisposableLanguageServer {
+  private int exitCode = 1;
 
   @Inject
   public TestLanguageServer() {}
@@ -36,6 +40,7 @@ public class TestLanguageServer implements LanguageServer {
 
   @Override
   public CompletableFuture<Object> shutdown() {
+    exitCode = 0;
     return null;
   }
 
@@ -52,5 +57,14 @@ public class TestLanguageServer implements LanguageServer {
   @Override
   public WorkspaceService getWorkspaceService() {
     return null;
+  }
+
+  @Override
+  public int getExitCode() {
+    return exitCode;
+  }
+
+  public void revokeShutdown() {
+    exitCode = 1;
   }
 }


### PR DESCRIPTION
Support Termination Requests #590

LSP spec says below about "shutdown" call:
"Clients must not send any notifications other than exit or requests to a server to which they have sent a shutdown request. If a server receives requests after a shutdown request those requests should error with InvalidRequest."

While the VScode API doesn't mention anything specific about the call in [references/vscode-api#Extension](https://code.visualstudio.com/api/references/vscode-api#Extension). It does mention it in [references/activation-events](https://code.visualstudio.com/api/references/activation-events)

And an issue [vscode issue](https://github.com/microsoft/vscode/issues/35196), mentions "VScode only wait for shutdown (e.g. for the promise to be resolved) and wait in total 5 seconds. There is not waiting happening on exit."