### PR TITLE
Make parsing interruptible 

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/engine/CobolLanguageEngine.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/engine/CobolLanguageEngine.java
@@ -37,6 +37,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,20 +54,24 @@ import static java.util.stream.Collectors.toList;
  */
 @Slf4j
 @Singleton
+@SuppressWarnings("WeakerAccess")
 public class CobolLanguageEngine implements ThreadInterruptAspect {
 
   private TextPreprocessor preprocessor;
   private DefaultErrorStrategy defaultErrorStrategy;
   private MessageService messageService;
+  private ParseTreeListener treeListener;
 
   @Inject
   public CobolLanguageEngine(
       TextPreprocessor preprocessor,
       DefaultErrorStrategy defaultErrorStrategy,
-      MessageService messageService) {
+      MessageService messageService,
+      ParseTreeListener treeListener) {
     this.preprocessor = preprocessor;
     this.defaultErrorStrategy = defaultErrorStrategy;
     this.messageService = messageService;
+    this.treeListener = treeListener;
   }
 
   /**
@@ -100,6 +105,7 @@ public class CobolLanguageEngine implements ThreadInterruptAspect {
     parser.removeErrorListeners();
     parser.addErrorListener(listener);
     parser.setErrorHandler(defaultErrorStrategy);
+    parser.addParseListener(treeListener);
 
     CobolParser.StartRuleContext tree = parser.startRule();
 

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/InterruptingTreeListener.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/InterruptingTreeListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.core.visitor;
+
+import com.broadcom.lsp.cobol.core.annotation.CheckThreadInterruption;
+import com.broadcom.lsp.cobol.core.annotation.ThreadInterruptAspect;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+/**
+ * This class used to implicitly check if the current interrupted while the parsing by the main
+ * grammar.
+ */
+public class InterruptingTreeListener implements ParseTreeListener, ThreadInterruptAspect {
+
+  @Override
+  @CheckThreadInterruption
+  public void visitTerminal(TerminalNode node) {
+    // Implicitly checks if the thread interrupted
+  }
+
+  @Override
+  @CheckThreadInterruption
+  public void visitErrorNode(ErrorNode node) {
+    // Implicitly checks if the thread interrupted
+  }
+
+  @Override
+  @CheckThreadInterruption
+  public void enterEveryRule(ParserRuleContext ctx) {
+    // Implicitly checks if the thread interrupted
+  }
+
+  @Override
+  @CheckThreadInterruption
+  public void exitEveryRule(ParserRuleContext ctx) {
+    // Implicitly checks if the thread interrupted
+  }
+}

--- a/server/src/main/java/com/broadcom/lsp/cobol/domain/modules/EngineModule.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/domain/modules/EngineModule.java
@@ -40,11 +40,13 @@ import com.broadcom.lsp.cobol.core.preprocessor.delegates.util.ReplacingServiceI
 import com.broadcom.lsp.cobol.core.preprocessor.delegates.writer.CobolLineWriter;
 import com.broadcom.lsp.cobol.core.preprocessor.delegates.writer.CobolLineWriterImpl;
 import com.broadcom.lsp.cobol.core.strategy.CobolErrorStrategy;
+import com.broadcom.lsp.cobol.core.visitor.InterruptingTreeListener;
 import com.broadcom.lsp.cobol.service.delegates.communications.Communications;
 import com.broadcom.lsp.cobol.service.delegates.communications.ServerCommunications;
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
 
 import static com.google.inject.name.Names.named;
 
@@ -65,8 +67,10 @@ public class EngineModule extends AbstractModule {
     bind(MessageService.class).to(PropertiesMessageService.class);
     bind(LocaleStore.class).to(LocaleStoreImpl.class);
     bind(Communications.class).to(ServerCommunications.class);
-    bind(String.class).annotatedWith(named("resourceFileLocation")).toInstance("resourceBundles/messages");
-
+    bind(ParseTreeListener.class).to(InterruptingTreeListener.class);
+    bind(String.class)
+        .annotatedWith(named("resourceFileLocation"))
+        .toInstance("resourceBundles/messages");
 
     bind(CobolLineReWriter.class)
         .annotatedWith(named("entriesMarker"))

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/engine/CobolLanguageEngineTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/engine/CobolLanguageEngineTest.java
@@ -25,6 +25,7 @@ import com.broadcom.lsp.cobol.core.strategy.CobolErrorStrategy;
 import com.broadcom.lsp.cobol.service.CopybookProcessingMode;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -57,9 +58,10 @@ class CobolLanguageEngineTest {
     TextPreprocessor preprocessor = mock(TextPreprocessor.class);
     MessageService mockMessageService = mock(MessageService.class);
     CobolErrorStrategy cobolErrorStrategy = new CobolErrorStrategy();
+    ParseTreeListener treeListener = mock(ParseTreeListener.class);
     cobolErrorStrategy.setMessageService(mockMessageService);
     CobolLanguageEngine engine =
-        new CobolLanguageEngine(preprocessor, cobolErrorStrategy, mockMessageService);
+        new CobolLanguageEngine(preprocessor, cobolErrorStrategy, mockMessageService, treeListener);
     when(mockMessageService.getMessage(anyString(), anyString(), anyString())).thenReturn("");
     Locality locality =
         Locality.builder()


### PR DESCRIPTION
`ParseTreeListener` is used to track the abstract syntax tree building and its methods called on each rule. So, it may be used to interrupt the parsing. 