### PR TITLE
fix: Copybook with Name in Quotes Not Recognized #620

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorListenerImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/GrammarPreprocessorListenerImpl.java
@@ -19,6 +19,7 @@ import com.broadcom.lsp.cobol.core.messages.MessageService;
 import com.broadcom.lsp.cobol.core.model.*;
 import com.broadcom.lsp.cobol.core.preprocessor.ProcessingConstants;
 import com.broadcom.lsp.cobol.core.preprocessor.TextPreprocessor;
+import com.broadcom.lsp.cobol.core.preprocessor.delegates.util.PreprocessorStringUtils;
 import com.broadcom.lsp.cobol.core.preprocessor.delegates.util.ReplacingService;
 import com.broadcom.lsp.cobol.core.semantics.NamedSubContext;
 import com.broadcom.lsp.cobol.service.CopybookProcessingMode;
@@ -336,7 +337,7 @@ public class GrammarPreprocessorListenerImpl extends CobolPreprocessorBaseListen
   }
 
   private String retrieveCopybookName(@NonNull RuleContext context) {
-    return context.getText().toUpperCase();
+    return PreprocessorStringUtils.trimQuotes(context.getText().toUpperCase());
   }
 
   private String retrieveCopybookId() {

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/CobolDocumentModel.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/CobolDocumentModel.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Data
 @Slf4j
 public class CobolDocumentModel {
-  private static final String DELIMITER = "[ .\\[\\]()<>,*]+";
+  private static final String DELIMITER = "[ .\\[\\]()<>,*\"']+";
   private final List<Line> lines = new ArrayList<>();
   private final String text;
   private AnalysisResult analysisResult;

--- a/server/src/test/antlr4/com/broadcom/usecase/UseCasePreprocessor.g4
+++ b/server/src/test/antlr4/com/broadcom/usecase/UseCasePreprocessor.g4
@@ -108,7 +108,7 @@ cpyIdentifier
    ;
 
 cpyName
-   : IDENTIFIER | COPYBOOKNAME
+   : IDENTIFIER | COPYBOOKNAME | QUOTED_COPYBOOKNAME | STRINGLITERAL
    ;
 
 START : '{';
@@ -131,6 +131,7 @@ STRINGLITERAL : ["] ~["]* ["];
 IDENTIFIER : [a-zA-Z0-9:]+ ([-_]+ [a-zA-Z0-9:]+)*;
 
 COPYBOOKNAME : [a-zA-Z0-9#@$]+ ([-_]+ [a-zA-Z0-9#@$]+)*;
+QUOTED_COPYBOOKNAME : '\'' + COPYBOOKNAME + '\'';
 
 // whitespace, line breaks, comments, ...
 NEWLINE : '\r'? '\n' -> channel(HIDDEN);

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookNameWithQuotes.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookNameWithQuotes.java
@@ -1,0 +1,37 @@
+package com.broadcom.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cobol.positive.CobolText;
+import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This test checks that the copybook name with quotes processed successfully
+ */
+class TestCopybookNameWithQuotes {
+  private static final String TEXT =
+          "        IDENTIFICATION DIVISION.\n"
+          + "          PROGRAM-ID. PARTEST.\n"
+          + "          DATA DIVISION.\n"
+          + "          WORKING-STORAGE SECTION.\n"
+          + "          PROCEDURE DIVISION.\n";
+
+  private static final String QUITES_LOWERCASE = "            COPY {~'cpbtest'}.\n";
+  private static final String DOUBLE_QUITES = "            COPY {~\"CPBTEST\"}.\n";
+
+  private static final String COPYBOOK =
+      "         {#*PROGA}.";
+
+  @Test
+  void assertCopybookWithQuotesProcessing() {
+    UseCaseEngine.runTest(TEXT + QUITES_LOWERCASE, List.of(new CobolText("CPBTEST", COPYBOOK)), Map.of());
+  }
+
+  @Test
+  void assertCopybookWithDoubleQuotesProcessing() {
+    UseCaseEngine.runTest(TEXT + DOUBLE_QUITES, List.of(new CobolText("CPBTEST", COPYBOOK)), Map.of());
+  }
+
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCasePreprocessorListener.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCasePreprocessorListener.java
@@ -15,6 +15,7 @@
 
 package com.broadcom.lsp.cobol.usecases.engine;
 
+import com.broadcom.lsp.cobol.core.preprocessor.delegates.util.PreprocessorStringUtils;
 import com.broadcom.usecase.UseCasePreprocessorBaseListener;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -186,7 +187,7 @@ public class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener
       CopybookStatementContext ctx, Map<String, List<Location>> copybookUsages) {
     return it ->
         processToken(
-            it.cpyName().getText(), ctx, it.replacement(), copybookUsages, ctx.diagnostic());
+            PreprocessorStringUtils.trimQuotes(it.cpyName().getText().toUpperCase()), ctx, it.replacement(), copybookUsages, ctx.diagnostic());
   }
 
   @Override


### PR DESCRIPTION
1. Normalize token name for copybooks implementation
2. Unit tests
3. Update usecase engine
3. +1 Use case for testing purpose