### PR TITLE
Fix analysis stop on a client exception

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/model/CopybookModel.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/model/CopybookModel.java
@@ -26,4 +26,15 @@ public class CopybookModel {
   private String name;
   private String uri;
   private String content;
+
+  /**
+   * Create an empty {@link CopybookModel} that contains only the name if the content could not be
+   * resolved
+   *
+   * @param name - a copybook name
+   * @return an empty {@link CopybookModel} instance
+   */
+  public static CopybookModel empty(String name) {
+    return new CopybookModel(name, null, null);
+  }
 }


### PR DESCRIPTION
The client with an incorrect Zowe profile may produce an exception that may stop the analysis without any notifications. The exception should be caught explicitly.

Fix: #643 