### PR TITLE
Make copybook coloring work without analysis

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -31,6 +31,7 @@
     ],
     "activationEvents": [
         "onLanguage:COBOL",
+        "onLanguage:COBOL Copybook",
         "workspaceContains:/.c4z"
     ],
     "icon": "resources/logo.png",
@@ -63,9 +64,14 @@
                 "id": "COBOL",
                 "extensions": [
                     ".cbl",
-                    ".cpy",
                     ".cob",
                     ".cobol"
+                ]
+            },
+            {
+                "id": "COBOL Copybook",
+                "extensions": [
+                    ".cpy"
                 ]
             }
         ],
@@ -78,11 +84,24 @@
                     "meta.embedded.block.sql": "sql",
                     "meta.embedded.block.html": "html"
                 }
+            },
+            {
+                "language": "COBOL Copybook",
+                "scopeName": "source.cobol",
+                "path": "./syntaxes/COBOL.tmLanguage.json",
+                "embeddedLanguages": {
+                    "meta.embedded.block.sql": "sql",
+                    "meta.embedded.block.html": "html"
+                }
             }
         ],
         "snippets": [
             {
                 "language": "COBOL",
+                "path": "./snippets.json"
+            },
+            {
+                "language": "COBOL Copybook",
                 "path": "./snippets.json"
             }
         ],

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/CobolTextDocumentService.java
@@ -206,8 +206,7 @@ public class CobolTextDocumentService
     }
 
     String text = params.getTextDocument().getText();
-    String langId = params.getTextDocument().getLanguageId();
-    registerEngineAndAnalyze(uri, langId, text);
+    registerEngineAndAnalyze(uri, text);
   }
 
   @Override
@@ -254,15 +253,13 @@ public class CobolTextDocumentService
     docs.forEach((key, value) -> analyzeDocumentFirstTime(key, value.getText(), event.verbose));
   }
 
-  private void registerEngineAndAnalyze(String uri, String languageType, String text) {
+  private void registerEngineAndAnalyze(String uri, String text) {
     String fileExtension = extractExtension(uri);
     if (fileExtension != null && !isCobolFile(fileExtension)) {
       communications.notifyThatExtensionIsUnsupported(fileExtension);
-    } else if (isCobolFile(languageType)) {
+    } else {
       communications.notifyThatLoadingInProgress(uri);
       analyzeDocumentFirstTime(uri, text, false);
-    } else {
-      communications.notifyThatEngineNotFound(languageType);
     }
   }
 

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/Communications.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/Communications.java
@@ -23,8 +23,6 @@ import java.util.Map;
 public interface Communications {
   void notifyThatLoadingInProgress(String uri);
 
-  void notifyThatEngineNotFound(String languageType);
-
   void publishDiagnostics(Map<String, List<Diagnostic>> diagnostics);
 
   void cancelProgressNotification(String uri);

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunications.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunications.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
 import java.util.*;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import static java.util.concurrent.CompletableFuture.runAsync;
@@ -64,20 +63,6 @@ public class ServerCommunications implements Communications {
   }
 
   /**
-   * This method raise a notification message back to the client if is unable to found a language
-   * engine for a given document ID
-   *
-   * @param languageType enum that represent the language type
-   */
-  @Override
-  public void notifyThatEngineNotFound(String languageType) {
-    runAsync(
-        () ->
-            showMessage(
-                Error, messageService.getMessage("Communications.noLangEngine", languageType)));
-  }
-
-  /**
    * The "work in progress" message should be shown after 3 seconds if the analysis not finished
    * yet. If cancelProgressNotification was invoked then the message won't be shown on the client.
    *
@@ -87,17 +72,19 @@ public class ServerCommunications implements Communications {
   public void notifyThatLoadingInProgress(String uri) {
     String decodedUri = files.decodeURI(uri);
     uriInProgress.add(decodedUri);
-    customExecutor.getScheduledThreadPoolExecutor().schedule(
-        () -> {
-          if (uriInProgress.remove(decodedUri)) {
-            showMessage(
-                Info,
-                messageService.getMessage(
-                    "Communications.syntaxAnalysisInProgress", retrieveFileName(decodedUri)));
-          }
-        },
-        3,
-        SECONDS);
+    customExecutor
+        .getScheduledThreadPoolExecutor()
+        .schedule(
+            () -> {
+              if (uriInProgress.remove(decodedUri)) {
+                showMessage(
+                    Info,
+                    messageService.getMessage(
+                        "Communications.syntaxAnalysisInProgress", retrieveFileName(decodedUri)));
+              }
+            },
+            3,
+            SECONDS);
   }
 
   /**

--- a/server/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/src/main/resources/resourceBundles/messages_en.properties
@@ -18,7 +18,6 @@ CobolVisitor.invalidDefMsg=Invalid definition for: %s
 CobolVisitor.misspelledWord=A misspelled word, maybe you want to put %s
 CobolVisitor.progIDIssueMsg=There is an issue with PROGRAM-ID paragraph
 CobolVisitor.paragraphNotDefined=The following paragraph is not defined: %s
-Communications.noLangEngine=Cannot find a language engine for the given language ID: %s
 Communications.syntaxAnalysisInProgress=%s : Syntax analysis in progress
 Communications.noSyntaxError=No syntax errors detected in %s
 Communications.extUnsupported=The given document extension is unsupported: %s

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -126,14 +126,6 @@ class CobolTextDocumentServiceTest extends MockTextDocumentService {
   }
 
   @Test
-  void testIncorrectLanguageId() {
-    service.didOpen(
-        new DidOpenTextDocumentParams(
-            new TextDocumentItem(UseCaseUtils.DOCUMENT_URI, "incorrectId", 1, TEXT_EXAMPLE)));
-    verify(communications).notifyThatEngineNotFound("incorrectId");
-  }
-
-  @Test
   void testDidSave() {
     TextDocumentIdentifier saveDocumentIdentifier =
         new TextDocumentIdentifier(UseCaseUtils.DOCUMENT_URI);

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/communications/ServerCommunicationsTest.java
@@ -22,7 +22,6 @@ import com.google.inject.Provider;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.DOCUMENT_URI;
 import static org.eclipse.lsp4j.MessageType.Error;
@@ -62,7 +60,6 @@ class ServerCommunicationsTest {
   @Mock private MessageService messageService;
 
   @Mock private CustomThreadPoolExecutor customExecutor;
-  @Mock private ScheduledExecutorService executor;
 
   @BeforeEach
   void init(TestInfo info) {
@@ -80,23 +77,6 @@ class ServerCommunicationsTest {
     assertDocumentAnalysedNotification(DOCUMENT_URI, "document.cbl");
     assertDocumentAnalysedNotification("document.cbl", "document.cbl");
     assertDocumentAnalysedNotification("", "");
-  }
-
-  /**
-   * Method {@link ServerCommunications#notifyThatEngineNotFound(String)} should asynchronously
-   * populate message with a language type on the client
-   */
-  @Test
-  void testNotifyThatEngineNotFound() {
-    String data = UUID.randomUUID().toString();
-    when(messageService.getMessage(anyString(), anyString()))
-        .thenReturn("Cannot find a language engine for the given language ID: %s");
-    communications.notifyThatEngineNotFound(data);
-    verify(client, timeout(TEST_TIMEOUT))
-        .showMessage(
-            eq(
-                new MessageParams(
-                    Error, messageService.getMessage("Communications.noLangEngine", data))));
   }
 
   /**


### PR DESCRIPTION
Provide a new language ID for copybooks to allow coloring without applying syntax analysis. Remove language ID check on the server due to is guaranteed by the client.
Closes #654 