### PR TITLE
Fix exposing semantic errors to document

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
@@ -438,8 +438,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   @Override
   public Class visitParagraphNameUsage(ParagraphNameUsageContext ctx) {
     String name = ctx.getText().toUpperCase();
-    getLocality(ctx.getStart())
-        .ifPresent(l -> groupContext.addCandidateUsage(name, l));
+    getLocality(ctx.getStart()).ifPresent(l -> groupContext.addCandidateUsage(name, l));
     return visitChildren(ctx);
   }
 
@@ -566,7 +565,8 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   }
 
   private String extractErrorStatementText(@NonNull Token childToken, @NonNull Token parentToken) {
-    List<Token> tokenList = tokenStream.getTokens(childToken.getTokenIndex(), parentToken.getTokenIndex());
+    List<Token> tokenList =
+        tokenStream.getTokens(childToken.getTokenIndex(), parentToken.getTokenIndex());
 
     return Optional.ofNullable(tokenList).stream()
         .flatMap(Collection::stream)
@@ -580,6 +580,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
         .uri(start.getUri())
         .range(new Range(start.getRange().getStart(), stop.getRange().getEnd()))
         .recognizer(CobolVisitor.class)
+        .copybookId(start.getCopybookId())
         .build();
   }
 
@@ -617,7 +618,12 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   private void areaAWarning(Token token) {
     getLocality(token)
         .filter(it -> it.getRange().getStart().getCharacter() > 10)
-        .ifPresent(it -> throwException(token.getText(), it, messageService.getMessage("CobolVisitor.AreaAWarningMsg")));
+        .ifPresent(
+            it ->
+                throwException(
+                    token.getText(),
+                    it,
+                    messageService.getMessage("CobolVisitor.AreaAWarningMsg")));
   }
 
   private void areaBWarning(@NonNull List<Token> tokenList) {
@@ -628,14 +634,20 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
                     locality -> {
                       int charPosition = locality.getRange().getStart().getCharacter();
                       if (charPosition > 6 && charPosition < 11 && token.getChannel() != 1) {
-                        throwException(token.getText(), locality, messageService.getMessage("CobolVisitor.AreaBWarningMsg"));
+                        throwException(
+                            token.getText(),
+                            locality,
+                            messageService.getMessage("CobolVisitor.AreaBWarningMsg"));
                       }
                     }));
   }
 
   private void checkProgramName(Token token) {
     if (programName == null) {
-      getLocality(token).ifPresent(it -> throwException("", it, messageService.getMessage("CobolVisitor.progIDIssueMsg")));
+      getLocality(token)
+          .ifPresent(
+              it ->
+                  throwException("", it, messageService.getMessage("CobolVisitor.progIDIssueMsg")));
     } else {
       checkProgramNameIdentical(token);
     }
@@ -644,14 +656,18 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   private void checkProgramNameIdentical(Token token) {
     String text = PreprocessorStringUtils.trimQuotes(token.getText());
     if (!programName.equals(text)) {
-      getLocality(token).ifPresent(it -> throwException(programName, it, messageService.getMessage("CobolVisitor.identicalProgMsg")));
+      getLocality(token)
+          .ifPresent(
+              it ->
+                  throwException(
+                      programName, it, messageService.getMessage("CobolVisitor.identicalProgMsg")));
     }
   }
 
   // NOTE: CobolVisitor is not managed by Guice DI, so can't use annotation here.
   @Override
   public Class visitChildren(RuleNode node) {
-    if(Thread.interrupted()) {
+    if (Thread.interrupted()) {
       LOG.debug("visitChildren method interrupted by user");
       throw new ParseCancellationException("Parsing interrupted by user.");
     }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestReplacingForSeveralTokensInOneLine.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestReplacingForSeveralTokensInOneLine.java
@@ -42,7 +42,7 @@ class TestReplacingForSeveralTokensInOneLine {
           + "       01 {$*ABCDE-PARENT}.\r\n"
           + "       PROCEDURE DIVISION.\r\n"
           + "       {#*MAIN-LINE}.\r\n"
-          + "       COPY {~REPL} REPLACING ==:TAG:== BY ==ABCDE==.\r\n"
+          + "       {_COPY {~REPL} REPLACING ==:TAG:== BY ==ABCDE==.|invalid|struct_}\r\n"
           + "           GOBACK.";
 
   private static final String REPL =

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSemanticErrorsFromCopybooksShownInDocument.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSemanticErrorsFromCopybooksShownInDocument.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package com.broadcom.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cobol.positive.CobolText;
+import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.broadcom.lsp.cobol.service.delegates.validations.SourceInfoLevels.INFO;
+import static org.eclipse.lsp4j.DiagnosticSeverity.Information;
+
+/**
+ * This test checks that semantic errors that appear in a copybook exposed in the COBOL document on
+ * the COPY statement.
+ */
+class TestSemanticErrorsFromCopybooksShownInDocument {
+
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           {_COPY {~MOVE}.|1_}\n"
+          + "           GOBACK.";
+
+  private static final String MOVE = "             MOVE 0 to {$SMTH|1}.";
+  private static final String MOVE_NAME = "MOVE";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        List.of(new CobolText(MOVE_NAME, MOVE)),
+        Map.of(
+            "1",
+            new Diagnostic(null, "Invalid definition for: SMTH", Information, INFO.getText())));
+  }
+}


### PR DESCRIPTION
The actual problem is that the `CobolVisitor` does not set the copybook ID for interval errors. 
Fix #652 

@asatklichov 
@grianbrcom 
@ap891843 