### PR TITLE
Fix analysis stop on a client exception

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/service/CopybookServiceImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/CopybookServiceImpl.java
@@ -23,6 +23,8 @@ import com.broadcom.lsp.cobol.domain.event.model.DataEvent;
 import com.broadcom.lsp.cobol.service.utils.FileSystemService;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.gson.JsonPrimitive;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -100,7 +102,7 @@ public class CopybookServiceImpl implements CopybookService, ThreadInterruptAspe
     try {
       return copybookCache.get(
           copybookName, () -> resolveSync(copybookName, documentUri, copybookProcessingMode));
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
       LOG.error("Can't resolve copybook '{}'.", copybookName, e);
       return new CopybookModel(copybookName, null, null);
     }

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -474,7 +474,7 @@ class CobolTextDocumentServiceTest extends MockTextDocumentService {
     service.getFutureMap().get(UseCaseUtils.DOCUMENT_URI).get();
     service.definition(
         new TextDocumentPositionParams(
-            new TextDocumentIdentifier(UseCaseUtils.DOCUMENT_URI), new Position()));
+            new TextDocumentIdentifier(UseCaseUtils.DOCUMENT_URI), new Position())).get();
     verify(occurrences)
         .findDefinitions(any(CobolDocumentModel.class), any(TextDocumentPositionParams.class));
   }
@@ -498,7 +498,7 @@ class CobolTextDocumentServiceTest extends MockTextDocumentService {
     ReferenceParams referenceParams = new ReferenceParams();
     referenceParams.setContext(new ReferenceContext(true));
     referenceParams.setTextDocument(new TextDocumentIdentifier(UseCaseUtils.DOCUMENT_URI));
-    service.references(referenceParams);
+    service.references(referenceParams).get();
     verify(occurrences)
         .findReferences(
             any(CobolDocumentModel.class),

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookServiceTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookServiceTest.java
@@ -288,6 +288,16 @@ class CopybookServiceTest {
     assertEquals(new CopybookModel(VALID_CPY_NAME, null, null), copybookModel);
   }
 
+  @Test
+  void testThatMiddlewareThrowsRuntimeException() {
+    when(settingsService.getConfiguration("copybook-resolve", "document", VALID_CPY_NAME))
+        .thenThrow(new RuntimeException("Something is wrong"));
+    CopybookService copybookService = createCopybookService();
+    CopybookModel copybookModel = copybookService.resolve(VALID_CPY_NAME, DOCUMENT_URI, ENABLED);
+
+    assertEquals(new CopybookModel(VALID_CPY_NAME, null, null), copybookModel);
+  }
+
   private CopybookService createCopybookService() {
     return new CopybookServiceImpl(broker, settingsService, files, 3, 3, "HOURS");
   }


### PR DESCRIPTION
The fix catch all possible exceptions from Guava cache and handle them correctly.

Closes #643

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>