### PR TITLE
HANDLE AID CLEAR() Produces a Syntax Error in EXEC CICS

### DIFF
--- a/server/src/main/antlr4/com/broadcom/lsp/cobol/core/parser/CICSParser.g4
+++ b/server/src/main/antlr4/com/broadcom/lsp/cobol/core/parser/CICSParser.g4
@@ -412,7 +412,7 @@ cics_getnext_container: (CONTAINER cics_data_area | BROWSETOKEN cics_data_value 
 /** HANDLE CONDITION / HANDLE AID / HANDLE ABEND: */
 cics_handle: HANDLE (cics_handle_abend | cics_handle_aid | cics_handle_condition);
 cics_handle_abend: ABEND (CANCEL | PROGRAM cics_name | LABEL cics_label | RESET | cics_resp)*;
-cics_handle_aid: AID (ANYKEY (cics_label)? | CLEAR (cics_label)? | CLRPARTN (cics_label)? | ENTER (cics_label)? |
+cics_handle_aid: AID (ANYKEY (cics_label)? | CLEAR (empty_parens | cics_label)? | CLRPARTN (cics_label)? | ENTER (cics_label)? |
                  LIGHTPEN (cics_label)? | OPERID  (cics_label)? | pa_option (cics_label)? | pf_option (cics_label)? |
                  TRIGGER  (cics_label)? | cics_resp)*;
 cics_handle_condition: CONDITION (mama cics_label? | cics_resp)+;
@@ -921,6 +921,7 @@ cics_mama: LPARENCHAR mama RPARENCHAR;
 cics_hhmmss: LPARENCHAR hhmmss RPARENCHAR;
 cics_label: LPARENCHAR paragraphNameUsage RPARENCHAR;
 cics_value: LPARENCHAR ptr_value RPARENCHAR;
+empty_parens: LPARENCHAR RPARENCHAR;
 
 cobolWord
    : IDENTIFIER | cics_only_words

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestExecCicsHandleAidClear.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestExecCicsHandleAidClear.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package com.broadcom.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This test checks the positive scenarios of using CLEAR in HANDLE AID.
+ * The valid usages are: CLEAR() and CLEAR(cics_label).
+ */
+class TestExecCicsHandleAidClear {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.   TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       LINKAGE SECTION.\n"
+          + "       01  {$*RESPONSE}                      PIC s9(8) COMP-4 VALUE 0.\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "       {#*10-EXIT}.\n"
+          + "            EXIT.\n"
+          + "       {#*NACT}.\n"
+          + "           EXEC CICS HANDLE AID CLEAR() END-EXEC.\n"
+          + "           EXEC CICS HANDLE AID CLEAR({#10-EXIT}) END-EXEC.\n";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, List.of(), Map.of());
+  }
+}


### PR DESCRIPTION
Closes #670

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>