### PR TITLE
Disable console logging for production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ To build extension run:
 
 ```$ cd clients/cobol-lsp-vscode-extension && npm install && npm run compile```
 
-To enable debug logging to the console, while you run the Java part in IDE change your run configuration. 
+You need to change the run configuration in your IDE to enable logging to the console while debugging the Java part. 
 Add `-Dlogback.configurationFile=server/localDev/logback.xml` to your `VM options` parameter. 
 The value can be `localDev/logback.xml` if the `server` folder is a root folder for your project.
 
@@ -79,4 +79,3 @@ Also, If you have some not obvious changes, it would be nice to provide a longer
 Contact the project developers.
 
 * supportChe4z.pdl@broadcom.com
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,10 @@ To build extension run:
 
 ```$ cd clients/cobol-lsp-vscode-extension && npm install && npm run compile```
 
+To enable debug logging to the console, while you run the Java part in IDE change your run configuration. 
+Add `-Dlogback.configurationFile=server/localDev/logback.xml` to your `VM options` parameter. 
+The value can be `localDev/logback.xml` if the `server` folder is a root folder for your project.
+
 ## Start contributing
 
 Before contributing to the project, fork the repository and clone it, or add it as a new remote if you have already cloned the original repository. All the commits should be pushed to the fork in order to open pull requests from it.

--- a/server/localDev/logback.xml
+++ b/server/localDev/logback.xml
@@ -17,24 +17,14 @@
 
 <configuration>
     <property name="HOME_LOG" value="${user.home}/LSPCobol/logs/app.log"/>
-    <appender name="FILE-ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${HOME_LOG}</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${user.home}/LSPCobol/logs/archived/app.%d{yyyy-MM-dd}.%i.log.zip
-            </fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>1GB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-
+    <appender name="STDOUT"
+              class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %replace(%msg){'(\\r\\n|\\r|\\n|\r\n|\r|\n)', ''}%n
             </pattern>
         </encoder>
     </appender>
-
-    <root level="${log.level:-ERROR}">
-        <appender-ref ref="FILE-ROLLING"/>
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Streaming the logging into stdout may cause JRPC issues.
Fixes #643

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>