### PR TITLE
Fix indicator check

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/CobolLineReaderImpl.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/CobolLineReaderImpl.java
@@ -18,11 +18,11 @@ import com.broadcom.lsp.cobol.core.messages.MessageService;
 import com.broadcom.lsp.cobol.core.model.*;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
-import lombok.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -145,16 +145,17 @@ public class CobolLineReaderImpl implements CobolLineReader {
       String indicatorArea, String uri, int lineNumber) {
     return ofNullable(INDICATORS.get(indicatorArea))
         .map(it -> new ResultWithErrors<>(it, List.of()))
-        .orElse(
-            new ResultWithErrors<>(
-                NORMAL,
-                List.of(
-                    createError(
-                        uri,
-                        messageService.getMessage("CobolLineReaderImpl.incorrectLineFormat"),
-                        lineNumber,
-                        INDICATOR_AREA_INDEX,
-                        INDICATOR_AREA_INDEX + 1))));
+        .orElseGet(
+            () ->
+                new ResultWithErrors<>(
+                    NORMAL,
+                    List.of(
+                        createError(
+                            uri,
+                            messageService.getMessage("CobolLineReaderImpl.incorrectLineFormat"),
+                            lineNumber,
+                            INDICATOR_AREA_INDEX,
+                            INDICATOR_AREA_INDEX + 1))));
   }
 
   @NonNull

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/strategy/CobolErrorStrategy.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/strategy/CobolErrorStrategy.java
@@ -67,9 +67,10 @@ public class CobolErrorStrategy extends DefaultErrorStrategy {
   }
 
   private String getExpectedToken(@NonNull Parser recognizer, InputMismatchException e) {
-    IntervalSet expecting = Optional.ofNullable(e)
-        .map(RecognitionException::getExpectedTokens)
-        .orElse(getExpectedTokens(recognizer));
+    IntervalSet expecting =
+        Optional.ofNullable(e)
+            .map(RecognitionException::getExpectedTokens)
+            .orElseGet(() -> getExpectedTokens(recognizer));
 
     return Optional.ofNullable(expecting)
         .map(exp -> exp.toString(recognizer.getVocabulary()))

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
@@ -593,11 +593,12 @@ public class CobolVisitor extends CobolParserBaseVisitor<Class> {
   private DataName2Context getDataName2Context(QualifiedInDataContext node) {
     return ofNullable(node.inData())
         .map(InDataContext::dataName2)
-        .orElse(
-            ofNullable(node.inTable())
-                .map(InTableContext::tableCall)
-                .map(TableCallContext::dataName2)
-                .orElse(null));
+        .orElseGet(
+            () ->
+                ofNullable(node.inTable())
+                    .map(InTableContext::tableCall)
+                    .map(TableCallContext::dataName2)
+                    .orElse(null));
   }
 
   private void checkVariableStructure(


### PR DESCRIPTION
False-positive indicator area errors are exposed to the log because optional calculations are greedy. They are changed to be lazy. Several similar issues are also fixed.

@grianbrcom 
@asatklichov 
@ap891843 