### PR TITLE
Remove prepopulating of settings.json with empty parameters for copybooks support

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/SettingsTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/SettingsTest.spec.ts
@@ -15,7 +15,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
 import {C4Z_FOLDER, GITIGNORE_FILE} from "../constants";
-import {createFileWithGivenPath, initializeSettings} from "../services/Settings";
+import {createFileWithGivenPath} from "../services/Settings";
 import {SettingsUtils} from "../services/util/SettingsUtils";
 
 const fsPath = "tmp-ws";
@@ -35,51 +35,6 @@ afterAll(() => {
     if (fs.existsSync(wsPath)) {
         fs.remove(wsPath);
     }
-});
-
-describe("Settings initialization tests", () => {
-
-    it("Update all settings if not present in workspace", async () => {
-        const updateSettings = jest.fn();
-        const inspectSettings = jest.fn().mockReturnValue({workspaceValue: undefined});
-        vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
-            update: updateSettings,
-            get: jest.fn().mockReturnValueOnce({prop1: "val1", prop2: "val2", prop3: "val3"})
-                .mockReturnValueOnce("val1")
-                .mockReturnValueOnce("val2")
-                .mockReturnValueOnce("val3"),
-            inspect: inspectSettings
-        });
-
-        initializeSettings();
-
-        expect(inspectSettings).toHaveBeenCalledTimes(3);
-        expect(updateSettings).toHaveBeenCalledWith("prop1", "val1", vscode.ConfigurationTarget.Workspace);
-        expect(updateSettings).toHaveBeenCalledWith("prop2", "val2", vscode.ConfigurationTarget.Workspace);
-        expect(updateSettings).toHaveBeenCalledWith("prop3", "val3", vscode.ConfigurationTarget.Workspace);
-        expect(updateSettings).toHaveBeenCalledTimes(3);
-    });
-
-    it("Update no settings if one present in workspace", async () => {
-        const updateSettings = jest.fn();
-        const inspectSettings = jest.fn().mockReturnValueOnce({workspaceValue: undefined})
-            .mockReturnValueOnce({workspaceValue: "val2"})
-            .mockReturnValueOnce({workspaceValue: undefined});
-        vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
-            update: updateSettings,
-            get: jest.fn().mockReturnValueOnce({prop1: "val1", prop2: "val2", prop3: "val3"})
-                .mockReturnValueOnce("val1")
-                .mockReturnValueOnce("val2")
-                .mockReturnValueOnce("val3"),
-            inspect: inspectSettings
-        });
-
-        initializeSettings();
-
-        expect(inspectSettings).toHaveBeenCalledTimes(2);
-        expect(updateSettings).toHaveBeenCalledTimes(0);
-    });
-
 });
 
 describe(".gitignore file in .c4z folder tests", () => {

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -21,7 +21,7 @@ import {activate} from "../extension";
 import {CopybooksCodeActionProvider} from "../services/copybook/CopybooksCodeActionProvider";
 import {LanguageClientService} from "../services/LanguageClientService";
 import {TelemetryService} from "../services/reporter/TelemetryService";
-import {createFileWithGivenPath, initializeSettings} from "../services/Settings";
+import {createFileWithGivenPath} from "../services/Settings";
 
 jest.mock("../commands/ChangeDefaultZoweProfile");
 jest.mock("../commands/EditDatasetPaths");
@@ -75,7 +75,6 @@ describe("Check plugin extension for cobol starts successfully.", () => {
 
     test("start extension", async () => {
         await activate(context);
-        expect(initializeSettings).toHaveBeenCalledTimes(1);
         expect(TelemetryService.registerEvent).toHaveBeenCalledWith("log", ["bootstrap", "experiment-tag"], "Extension activation event was triggered");
 
         expect(vscode.workspace.onDidChangeConfiguration).toBeCalled();
@@ -109,7 +108,6 @@ describe("Check plugin extension for cobol fails.", () => {
 
     test("start fails.", async () => {
         await activate(context);
-        expect(initializeSettings).toHaveBeenCalledTimes(1);
         expect(TelemetryService.registerEvent).toHaveBeenCalledWith("log", ["bootstrap", "experiment-tag"], "Extension activation event was triggered");
         expect(vscode.window.showErrorMessage).toBeCalledTimes(1);
     });

--- a/clients/cobol-lsp-vscode-extension/src/extension.ts
+++ b/clients/cobol-lsp-vscode-extension/src/extension.ts
@@ -29,7 +29,7 @@ import {Middleware} from "./services/Middleware";
 import {PathsService} from "./services/PathsService";
 import {ProfileService} from "./services/ProfileService";
 import {TelemetryService} from "./services/reporter/TelemetryService";
-import {createFileWithGivenPath, initializeSettings} from "./services/Settings";
+import {createFileWithGivenPath} from "./services/Settings";
 import {ZoweApi} from "./services/ZoweApi";
 import {resolveSubroutineURI} from "./services/util/SubroutineUtils";
 
@@ -53,7 +53,6 @@ function initialize() {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-    initializeSettings();
     initialize();
     TelemetryService.registerEvent("log", ["bootstrap", "experiment-tag"], "Extension activation event was triggered");
     try {

--- a/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/Settings.ts
@@ -17,21 +17,6 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { SETTINGS_CPY_SECTION } from "../constants";
 
-export function initializeSettings() {
-    const configuration = vscode.workspace.getConfiguration(SETTINGS_CPY_SECTION);
-    const properties = Object.keys(vscode.workspace.getConfiguration().get(SETTINGS_CPY_SECTION));
-
-    if (properties.every(isUndefinedInWorkspace)) {
-        properties.forEach(property => {
-            configuration.update(property, configuration.get(property), vscode.ConfigurationTarget.Workspace);
-        });
-    }
-}
-
-function isUndefinedInWorkspace(property: string): boolean {
-    return vscode.workspace.getConfiguration(SETTINGS_CPY_SECTION).inspect(property).workspaceValue === undefined;
-}
-
 /**
  * New file (e.g .gitignore) will be created or edited if exits, under project folder
  * (e.g. workspace/.c4z) with given  pattern


### PR DESCRIPTION
The plugin doesn't try to modify workspaces settings on its own.

Closes #701

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>