### PR TITLE
style: Check javadocs and tests

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -387,6 +387,7 @@
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                 </configuration>
                 <executions>
                     <execution>

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/outline/OutlineNodeNames.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/outline/OutlineNodeNames.java
@@ -17,18 +17,21 @@ package com.broadcom.lsp.cobol.core.semantics.outline;
 
 import lombok.experimental.UtilityClass;
 
+/**
+ * The class collects constants with various outline nodes names.
+ */
 @UtilityClass
 public class OutlineNodeNames {
-  public final String IDENTIFICATION_DIVISION = "IDENTIFICATION DIVISION";
-  public final String PROCEDURE_DIVISION = "PROCEDURE DIVISION";
-  public final String ENVIRONMENT_DIVISION = "ENVIRONMENT DIVISION";
-  public final String DATA_DIVISION = "DATA DIVISION";
-  public final String WORKING_STORAGE_SECTION = "WORKING-STORAGE SECTION";
-  public final String FILLER_NAME = "FILLER";
-  public final String PROGRAM_ID_PREFIX = "PROGRAM-ID ";
-  public final String CONFIGURATION_SECTION = "CONFIGURATION SECTION";
-  public final String INPUT_OUTPUT_SECTION = "INPUT-OUTPUT SECTION";
-  public final String FILE_SECTION = "FILE SECTION";
-  public final String LINKAGE_SECTION = "LINKAGE SECTION";
-  public final String LOCAL_STORAGE_SECTION = "LOCAL STORAGE SECTION";
+  public static final String IDENTIFICATION_DIVISION = "IDENTIFICATION DIVISION";
+  public static final String PROCEDURE_DIVISION = "PROCEDURE DIVISION";
+  public static final String ENVIRONMENT_DIVISION = "ENVIRONMENT DIVISION";
+  public static final String DATA_DIVISION = "DATA DIVISION";
+  public static final String WORKING_STORAGE_SECTION = "WORKING-STORAGE SECTION";
+  public static final String FILLER_NAME = "FILLER";
+  public static final String PROGRAM_ID_PREFIX = "PROGRAM-ID ";
+  public static final String CONFIGURATION_SECTION = "CONFIGURATION SECTION";
+  public static final String INPUT_OUTPUT_SECTION = "INPUT-OUTPUT SECTION";
+  public static final String FILE_SECTION = "FILE SECTION";
+  public static final String LINKAGE_SECTION = "LINKAGE SECTION";
+  public static final String LOCAL_STORAGE_SECTION = "LOCAL STORAGE SECTION";
 }

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtils.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtils.java
@@ -20,6 +20,9 @@ import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
+/**
+ * The utility class for work with document positions and ranges.
+ */
 @UtilityClass
 public class RangeUtils {
 

--- a/server/src/main/java/com/broadcom/lsp/cobol/domain/event/factory/AnalysisFinishedSubscriberFactory.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/domain/event/factory/AnalysisFinishedSubscriberFactory.java
@@ -20,6 +20,7 @@ import com.broadcom.lsp.cobol.domain.event.api.EventObserver;
 import com.broadcom.lsp.cobol.domain.event.impl.AnalysisFinishedEventSubscriber;
 import com.broadcom.lsp.cobol.domain.event.model.AnalysisFinishedEvent;
 
+/** This class is a factory for {@link AnalysisFinishedEventSubscriber} */
 public class AnalysisFinishedSubscriberFactory
     implements CopybookSubscriber<AnalysisFinishedEventSubscriber> {
 

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/KeywordCompletion.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/KeywordCompletion.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 
 import static com.broadcom.lsp.cobol.service.delegates.completions.CompletionOrder.KEYWORDS;
 
+/** implementation for adding keywords in the autocomplete list */
 @Singleton
 public class KeywordCompletion implements Completion {
   private CompletionStorage keywords;

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.broadcom.lsp.cobol.service.delegates.completions.CompletionOrder.PARAGRAPHS;
 
+/** implementation for adding paragraph names in the autocomplete list as identified by the parser */
 @Singleton
 public class ParagraphCompletion implements Completion {
 

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/SnippetCompletion.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/SnippetCompletion.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.broadcom.lsp.cobol.service.delegates.completions.CompletionOrder.SNIPPETS;
 
+/** implementation for adding snippets in the autocomplete list */
 @Singleton
 public class SnippetCompletion implements Completion {
   private CompletionStorage snippets;

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/VariableCompletion.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/completions/VariableCompletion.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.broadcom.lsp.cobol.service.delegates.completions.CompletionOrder.VARIABLES;
 
+/** implementation for adding variable names in the autocomplete list as identified by the parser */
 @Singleton
 public class VariableCompletion implements Completion {
 

--- a/server/src/style/checkstyle-suppressions.xml
+++ b/server/src/style/checkstyle-suppressions.xml
@@ -22,4 +22,24 @@
     <suppress checks="NewlineAtEndOfFile"
               files="Test_messageServiceEmptyFile_en.properties"/>
     <suppress checks="RightCurly" files="CobolLineIndicatorProcessorImpl.java"/>
+    <suppress checks="MethodName" files="[/\\]test[/\\]"/>
+
+    <!-- Temporal suppressions they MUST be fixed -->
+    <suppress checks="MissingJavadocType" files="ClientProvider.java"/>
+    <suppress checks="MissingJavadocType" files="Communications.java"/>
+    <suppress checks="MissingJavadocType" files="Formation.java"/>
+    <suppress checks="MissingJavadocType" files="Formations.java"/>
+    <suppress checks="MissingJavadocType" files="TrimFormation.java"/>
+    <suppress checks="MissingJavadocType" files="CompletionStorage.java"/>
+    <suppress checks="MissingJavadocType" files="LanguageEngineFacade.java"/>
+    <suppress checks="MissingJavadocType" files="CobolErrorStrategy.java"/>
+    <suppress checks="MissingJavadocType" files="CopybookSubscriber.java"/>
+    <suppress checks="MissingJavadocType" files="VariableLocationsTest.java"/>
+    <suppress checks="MissingJavadocType" files="CobolTextRegistry.java"/>
+    <suppress checks="MissingJavadocType" files="CopybooksMock.java"/>
+    <suppress checks="MissingJavadocType" files="AbstractCobolLinePreprocessorTest.java"/>
+    <suppress checks="MissingJavadocType" files="CustomToken.java"/>
+    <suppress checks="MissingJavadocType" files="DatabusTestConstants.java"/>
+    <suppress checks="MissingJavadocType" files="CopybookEventsTest.java"/>
+    <suppress checks="MissingJavadocType" files="DatabusBrokerTest.java"/>
 </suppressions>

--- a/server/src/style/checkstyle.xml
+++ b/server/src/style/checkstyle.xml
@@ -73,19 +73,22 @@
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
-        <!-- <module name="InvalidJavadocPosition"/>-->
+         <module name="InvalidJavadocPosition"/>
         <!-- <module name="JavadocMethod"/>-->
         <!-- <module name="JavadocType"/>-->
         <!-- <module name="JavadocVariable"/>-->
         <!-- <module name="JavadocStyle"/>-->
         <!-- <module name="MissingJavadocMethod"/>-->
+        <module name="MissingJavadocType">
+            <property name="scope" value="package"/>
+        </module>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
-        <!-- <module name="MemberName"/> -->
+        <module name="MemberName"/>
         <module name="MethodName"/>
         <module name="PackageName"/>
         <module name="ParameterName"/>
@@ -114,7 +117,14 @@
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+            <property name="allowEmptyCatches" value="true"/>
+        </module>
 
         <!-- Modifier Checks                                    -->
         <!-- See https://checkstyle.org/config_modifiers.html -->

--- a/server/src/test/java/com/broadcom/lsp/cobol/TestModule.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/TestModule.java
@@ -51,6 +51,7 @@ import static com.google.inject.name.Names.named;
 import static java.lang.System.getProperty;
 import static java.util.Optional.ofNullable;
 
+/** This module provides DI bindings for testing. */
 public class TestModule extends AbstractModule {
   private static final String PATH_TO_TEST_RESOURCES = "filesToTestPath";
 

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/HandleThreadInterruptionTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/annotation/HandleThreadInterruptionTest.java
@@ -14,7 +14,6 @@
  */
 package com.broadcom.lsp.cobol.core.annotation;
 
-import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/messages/LocaleStoreImplTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/messages/LocaleStoreImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+/** Test to check LocaleStoreImpl */
 class LocaleStoreImplTest {
   private Communications communications;
   private LocaleStoreImpl localeStore;

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/messages/LogLevelUtilsTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/messages/LogLevelUtilsTest.java
@@ -57,7 +57,7 @@ class LogLevelUtilsTest {
   private static class DummyElement {
     private final String info;
 
-    public DummyElement(String info) {
+    DummyElement(String info) {
       this.info = info;
     }
   }

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/messages/PropertiesMessageServiceTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/messages/PropertiesMessageServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/** Test to check PropertiesMessageService */
 class PropertiesMessageServiceTest {
 
   private static MessageService messageService;

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/impl/CobolLineReaderImplTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/reader/impl/CobolLineReaderImplTest.java
@@ -21,7 +21,6 @@ import com.broadcom.lsp.cobol.core.model.CobolLine;
 import com.google.common.collect.Lists;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/writer/impl/CobolLineWriterImplTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/preprocessor/delegates/writer/impl/CobolLineWriterImplTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/** Test to check CobolLineWriterImpl */
 class CobolLineWriterImplTest extends AbstractCobolLinePreprocessorTest {
   private static final String TEXT_TO_TEST =
       "078087                 PERFORM BBAB-MOVE-TO-DETAIL-MAP\r\n"

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/CobolVariableContextTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/CobolVariableContextTest.java
@@ -51,7 +51,7 @@ class CobolVariableContextTest {
   private static final String PARENT1 = "PARENT1";
 
   private static final Location ERROR_LOCALITY_1 = new Location(null, new Range(new Position(0, 5), new Position(0, 6)));
-  private static final Location ERROR_LOCALITY_2 =new Location(null, new Range(new Position(4, 5), new Position(0, 7)));
+  private static final Location ERROR_LOCALITY_2 = new Location(null, new Range(new Position(4, 5), new Position(0, 7)));
 
   private CobolVariableContext context;
   private Variable var1;

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/GroupContextTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/GroupContextTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.core.semantics;
 
 import com.broadcom.lsp.cobol.core.messages.MessageService;
@@ -60,7 +74,7 @@ class GroupContextTest {
     groupContext.addSectionDefinition("test2", Locality.builder().build());
     assertEquals(0, groupContext.generateParagraphErrors(messageService).size());
   }
-  
+
   private GroupContext prepareGroup(Locality locality) {
     GroupContext context = new GroupContext();
     context.addCandidateUsage("test", locality);

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtilsTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/outline/RangeUtilsTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/** Test to check RangeUtils */
 class RangeUtilsTest {
   private Position firstLine = new Position(1, 0);
   private Position secondLine = new Position(2, 0);

--- a/server/src/test/java/com/broadcom/lsp/cobol/domain/databus/impl/DatabusTestConstants.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/domain/databus/impl/DatabusTestConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.domain.databus.impl;
 
 import lombok.experimental.UtilityClass;

--- a/server/src/test/java/com/broadcom/lsp/cobol/domain/event/CopybookEventSubscribersTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/domain/event/CopybookEventSubscribersTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  */
 @Slf4j
 class CopybookEventSubscribersTest {
-  static class DatabusObserverTest implements EventObserver<DataEvent> {
+  private static class DatabusObserverTest implements EventObserver<DataEvent> {
     @Override
     public void observerCallback(DataEvent adaptedDataEvent) {
       LOG.debug("CALLBACK WORKS!");

--- a/server/src/test/java/com/broadcom/lsp/cobol/positive/FolderTextRegistry.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/positive/FolderTextRegistry.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.positive;
 
 import com.google.common.collect.ArrayListMultimap;

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CobolDocumentModelTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CobolDocumentModelTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+/** This test check functions of the {@link CobolDocumentModel}. */
 class CobolDocumentModelTest {
   private static final String TEXT =
       "        IDENTIFICATION DIVISION. \r\n"

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookProcessingModeTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/CopybookProcessingModeTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import static com.broadcom.lsp.cobol.service.CopybookProcessingMode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/** This test check getCopybookProcessingMode function of the {@link CopybookProcessingMode}. */
 class CopybookProcessingModeTest {
   private static final String EXT_SRC_DOC_URI = "file:///c%3A/.c4z/.extsrcs/EXTSRC.cbl";
   private static final String WRONG_EXT_SRC_DOC_URI = "file:///c%3A/.extsrcs/EXTSRC.cbl";

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/SubroutineServiceImplTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/SubroutineServiceImplTest.java
@@ -29,9 +29,12 @@ import static org.mockito.Mockito.*;
  * This test checks the entry points of the {@link SubroutineServiceImpl} implementation.
  */
 public class SubroutineServiceImplTest {
+  private static final String NAME = "NAME";
+  private static final String PRESENT_FILE = "existing";
+  private static final String MISSING_FILE = "nonExisting";
+
   @Test
   void subroutinesUriCached() {
-    String NAME = "NAME";
     CobolLanguageClient languageClient = mock(CobolLanguageClient.class);
     when(languageClient.resolveSubroutine(any()))
         .thenReturn(CompletableFuture.completedFuture("URI1"))
@@ -53,8 +56,6 @@ public class SubroutineServiceImplTest {
 
   @Test
   void subroutinesCachedEmptyResult() {
-    String PRESENT_FILE = "existing";
-    String MISSING_FILE = "nonExisting";
     CobolLanguageClient languageClient = mock(CobolLanguageClient.class);
     when(languageClient.resolveSubroutine(PRESENT_FILE)).thenReturn(CompletableFuture.completedFuture("URI"));
     when(languageClient.resolveSubroutine(MISSING_FILE)).thenReturn(CompletableFuture.completedFuture(null));

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/CompletionsChainTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/CompletionsChainTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 /** This tests checks the order of completion elements: 1. Variables 2. Keywords */
 class CompletionsChainTest {
 
-  private final CobolDocumentModel MODEL =
+  private static final CobolDocumentModel MODEL =
       new CobolDocumentModel(
           "TOKEN",
           AnalysisResult.builder()

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/SectionCompletionTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/SectionCompletionTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.service.delegates.completions;
 
 import com.broadcom.lsp.cobol.service.CobolDocumentModel;

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/SnippetCompletionTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/completions/SnippetCompletionTest.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/** Test to check SnippetCompletion */
 class SnippetCompletionTest {
   private static final String INSERT_TEXT = "WRITE ${1:item}";
   private static final String DOCUMENTATION_TEXT = "WRITE item";

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/formations/FormationsTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/formations/FormationsTest.java
@@ -30,24 +30,24 @@ import static org.mockito.Mockito.when;
 /** Test {@link Formations} class */
 class FormationsTest {
 
-  private final Formation formation_1 = mock(Formation.class);
-  private final Formation formation_2 = mock(Formation.class);
-  private final Formations formations = new Formations(Set.of(formation_1, formation_2));
+  private static final Formation FORMATION_1 = mock(Formation.class);
+  private static final Formation FORMATION_2 = mock(Formation.class);
+  private static final Formations FORMATIONS = new Formations(Set.of(FORMATION_1, FORMATION_2));
 
   @Test
   void WhenCobolDocumentModelNull_thenFormatReturnsEmptyList() {
-    List<TextEdit> format = formations.format(null);
+    List<TextEdit> format = FORMATIONS.format(null);
     assertEquals(0, format.size());
   }
 
   @Test
   void WhenCobolDocumentModelNonNull_thenFormatReturnsFormattedString() {
     CobolDocumentModel model = new CobolDocumentModel("SAMPLE TEXT FOR TEST");
-    List<TextEdit> response_1 = List.of(new TextEdit());
-    List<TextEdit> response_2 = List.of(new TextEdit(), new TextEdit());
-    when(formation_1.format(anyList())).thenReturn(response_1);
-    when(formation_2.format(anyList())).thenReturn(response_2);
-    List<TextEdit> format = formations.format(model);
+    List<TextEdit> response1 = List.of(new TextEdit());
+    List<TextEdit> response2 = List.of(new TextEdit(), new TextEdit());
+    when(FORMATION_1.format(anyList())).thenReturn(response1);
+    when(FORMATION_2.format(anyList())).thenReturn(response2);
+    List<TextEdit> format = FORMATIONS.format(model);
     // expect a flattened list of 2 responses.
     assertEquals(3, format.size());
   }

--- a/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/references/ElementOccurrencesTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/service/delegates/references/ElementOccurrencesTest.java
@@ -32,9 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Test {@link ElementOccurrences}
  */
 class ElementOccurrencesTest {
-    private static String URI = "uri";
-    private static String URI2 = "uri2";
-    private static String ELEMENT_NAME = "foo";
+    private static final String URI = "uri";
+    private static final String URI2 = "uri2";
+    private static final String ELEMENT_NAME = "foo";
 
     @Test
     void simpleCaseOfDefinitionsAndUsages() {

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/NegativeUseCase.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/NegativeUseCase.java
@@ -21,7 +21,6 @@ import org.eclipse.lsp4j.Diagnostic;
 
 import java.util.List;
 
-import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.analyzeForErrors;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/PositiveUseCase.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/PositiveUseCase.java
@@ -20,7 +20,6 @@ import org.eclipse.lsp4j.Diagnostic;
 
 import java.util.List;
 
-import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.analyzeForErrors;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookNameWithQuotes.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestCopybookNameWithQuotes.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.usecases;
 
 import com.broadcom.lsp.cobol.positive.CobolText;

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestIdmsControlSectionAll.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestIdmsControlSectionAll.java
@@ -51,7 +51,7 @@ class TestIdmsControlSectionAll {
             "            PROTOCOL. SUBSCHEMA-NAMES LENGTH IS 16\r\n"
                     + "            IDMS-RECORDS WITHIN WORKING-STORAGE LEVELS INCREMENTED 18";
 
-    private static final String IDMSCS_WITH_ONLY_PROTOCOL=
+    private static final String IDMSCS_WITH_ONLY_PROTOCOL =
             "            PROTOCOL.";
 
     private static final String IDMSCS_WITH_SSN_LEN_ERROR =

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestIdmsSections.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestIdmsSections.java
@@ -14,11 +14,7 @@
  */
 package com.broadcom.lsp.cobol.usecases;
 
-import com.broadcom.lsp.cobol.service.delegates.validations.SourceInfoLevels;
 import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestNoErrorOnCompilerDirectives.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestNoErrorOnCompilerDirectives.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.broadcom.lsp.cobol.service.delegates.validations.UseCaseUtils.analyzeForErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestOutlineTreeLineNumbers.java
@@ -30,12 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /** This test checks that Outline tree has correct lines numbers for elements */
 public class TestOutlineTreeLineNumbers {
   private static final String TEXT =
-      "00     IDENTIFICATION DIVISION.\n" +
-          "01     DATA DIVISION.\n" +
-          "02     WORKING-STORAGE SECTION.\n" +
-          "03     01 STRUCTNAME.\n" +
-          "04     03 VARNAME  PIC X(20).\n" +
-          "05     COPY BAR.";
+      "00     IDENTIFICATION DIVISION.\n"
+          + "01     DATA DIVISION.\n"
+          + "02     WORKING-STORAGE SECTION.\n"
+          + "03     01 STRUCTNAME.\n"
+          + "04     03 VARNAME  PIC X(20).\n"
+          + "05     COPY BAR.";
 
   @Test
   void test() {

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphDefined.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphDefined.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.usecases;
 
 import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
@@ -9,18 +23,19 @@ import java.util.Map;
 /** This test checks that performing defined paragraph processed correctly */
 class TestParagraphDefined {
   private static final String TEXT =
-"       IDENTIFICATION DIVISION.\n" +
-        "          PROGRAM-ID. TEST1.\n" +
-        "          DATA DIVISION.\n" +
-        "          WORKING-STORAGE SECTION.\n" +
-        "          PROCEDURE DIVISION.\n" +
-        "            PERFORM {#GET-DATA}.\n" +
-        "            STOP RUN.\n" +
-        "          {#*GET-DATA}.\n" +
-        "            DISPLAY \"\".";
-    @Test
-    void test() {
-        UseCaseEngine.runTest(TEXT, List.of(), Map.of());
-    }
+      "       IDENTIFICATION DIVISION.\n"
+          + "          PROGRAM-ID. TEST1.\n"
+          + "          DATA DIVISION.\n"
+          + "          WORKING-STORAGE SECTION.\n"
+          + "          PROCEDURE DIVISION.\n"
+          + "            PERFORM {#GET-DATA}.\n"
+          + "            STOP RUN.\n"
+          + "          {#*GET-DATA}.\n"
+          + "            DISPLAY \"\".";
+
+  @Test
+  void test() {
+      UseCaseEngine.runTest(TEXT, List.of(), Map.of());
+  }
 
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphNotDefined.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphNotDefined.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.usecases;
 
 import com.broadcom.lsp.cobol.service.delegates.validations.SourceInfoLevels;

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestPerformWithoutEndNotCauseNPE.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestPerformWithoutEndNotCauseNPE.java
@@ -48,7 +48,6 @@ class TestPerformWithoutEndNotCauseNPE extends NegativeUseCase {
 
   @Override
   protected void assertDiagnostics(List<Diagnostic> diagnostics) {
-    {
       assertEquals(2, diagnostics.size(), "Number of diagnostics");
 
       Diagnostic diagnostic = diagnostics.get(0);
@@ -59,6 +58,5 @@ class TestPerformWithoutEndNotCauseNPE extends NegativeUseCase {
       assertEquals(40, range.getStart().getCharacter(), "Diagnostic start character");
       assertEquals(8, range.getEnd().getLine(), "Diagnostic end line");
       assertEquals(50, range.getEnd().getCharacter(), "Diagnostic end character");
-    }
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSectionDefined.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSectionDefined.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.usecases;
 
 import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSqlIncludeStatementNotDefinedCorrectly.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSqlIncludeStatementNotDefinedCorrectly.java
@@ -15,12 +15,9 @@
 
 package com.broadcom.lsp.cobol.usecases;
 
-import com.broadcom.lsp.cobol.positive.CobolText;
 import com.broadcom.lsp.cobol.service.delegates.validations.SourceInfoLevels;
 import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestTitleStatement.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestTitleStatement.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
 package com.broadcom.lsp.cobol.usecases;
 
 import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestVariableUsageSeparatedByComma.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestVariableUsageSeparatedByComma.java
@@ -40,6 +40,6 @@ class TestVariableUsageSeparatedByComma {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, List.of(), Map.of(),List.of("SMTH"));
+    UseCaseEngine.runTest(TEXT, List.of(), Map.of(), List.of("SMTH"));
   }
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCasePreprocessorListener.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCasePreprocessorListener.java
@@ -45,7 +45,7 @@ import static org.antlr.v4.runtime.Lexer.HIDDEN;
  * UseCasePreprocessor.g4
  */
 public class UseCasePreprocessorListener extends UseCasePreprocessorBaseListener {
-  private List<String> PREDEFINED_VARIABLES =
+  private static final List<String> PREDEFINED_VARIABLES =
       List.of(
           "EIBAID",
           "EIBATT",


### PR DESCRIPTION
Checkstyle now checks tests too.
Each class must have a javadoc.
Class members must follow java naming convention.