### PR TITLE
[UI_tests] Add @types/node

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -5,6 +5,7 @@
     "@babel/core": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@cypress/webpack-preprocessor": "^5.4.8",
+    "@types/node": "^14.14.28",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
     "babel-loader": "^8.1.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -894,6 +894,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/node@^14.14.28":
+  version "14.14.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
+  integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
In order to use those [changes ](https://github.com/eclipse/che-che4z/pull/32) in the core library, we should add `@types/node` here as well.

Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>