### PR TITLE
feature: Collect and return ranges of paragraphs #777

### DIFF
--- a/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/GroupContext.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/GroupContext.java
@@ -32,7 +32,10 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class GroupContext {
   private final Multimap<String, Location> sections = HashMultimap.create();
+  private final Multimap<String, Location> sectionRanges = HashMultimap.create();
+
   private final Multimap<String, Location> paragraphs = HashMultimap.create();
+  private final Multimap<String, Location> paragraphsRanges = HashMultimap.create();
 
   private final Multimap<String, Locality> candidateUsageLocalities = HashMultimap.create();
 
@@ -46,12 +49,30 @@ public class GroupContext {
   }
 
   /**
+   * Adds a section range
+   * @param name is a section name
+   * @param location is a section location where it's range is a range of a section
+   */
+  public void addSectionRange(String name, Location location) {
+    sectionRanges.put(name, location);
+  }
+
+  /**
    * Adds a paragraph definition to the context
    * @param name is a paragraph name
    * @param locality is a paragraph locality
    */
   public void addParagraphDefinition(String name, Locality locality) {
     paragraphs.put(name, locality.toLocation());
+  }
+
+  /**
+   * Adds a paragraph range
+   * @param name is a paragraph name
+   * @param location is a paragraph location when it's range is a range of a paragraph
+   */
+  public void addParagraphRange(String name, Location location) {
+    paragraphsRanges.put(name, location);
   }
 
   /**
@@ -88,11 +109,27 @@ public class GroupContext {
   }
 
   /**
+   * Prepares and returns paragraphs ranges structure
+   * @return a map with a token and a collection of token locations
+   */
+  public Map<String, Collection<Location>> getParagraphRanges() {
+    return paragraphsRanges.asMap();
+  }
+
+  /**
    * Prepares and returns sections usages structure
    * @return a map with a token and a collection of token locations
    */
   public Map<String, Collection<Location>> getSectionUsages() {
     return prepareUsages(sections.keySet());
+  }
+
+  /**
+   * Prepares and returns sections ranges structure
+   * @return a map with a token and a collection of token locations
+   */
+  public Map<String, Collection<Location>> getSectionRanges() {
+    return sectionRanges.asMap();
   }
 
   /**
@@ -132,5 +169,4 @@ public class GroupContext {
         .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream()
             .map(Locality::toLocation).collect(Collectors.toList())));
   }
-
 }

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/SemanticContext.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/semantics/SemanticContext.java
@@ -35,8 +35,10 @@ public class SemanticContext {
   @Builder.Default Map<String, Collection<Location>> variableUsages = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> paragraphDefinitions = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> paragraphUsages = new HashMap<>();
+  @Builder.Default Map<String, Collection<Location>> paragraphRanges = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> sectionDefinitions = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> sectionUsages = new HashMap<>();
+  @Builder.Default Map<String, Collection<Location>> sectionRanges = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> constantDefinitions = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> constantUsages = new HashMap<>();
   @Builder.Default Map<String, Collection<Location>> copybookDefinitions = new HashMap<>();

--- a/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/core/visitor/CobolVisitor.java
@@ -18,10 +18,7 @@ package com.broadcom.lsp.cobol.core.visitor;
 import com.broadcom.lsp.cobol.core.CobolParser;
 import com.broadcom.lsp.cobol.core.CobolParserBaseVisitor;
 import com.broadcom.lsp.cobol.core.messages.MessageService;
-import com.broadcom.lsp.cobol.core.model.ErrorSeverity;
-import com.broadcom.lsp.cobol.core.model.Locality;
-import com.broadcom.lsp.cobol.core.model.ResultWithErrors;
-import com.broadcom.lsp.cobol.core.model.SyntaxError;
+import com.broadcom.lsp.cobol.core.model.*;
 import com.broadcom.lsp.cobol.core.model.variables.Variable;
 import com.broadcom.lsp.cobol.core.preprocessor.delegates.util.PreprocessorStringUtils;
 import com.broadcom.lsp.cobol.core.semantics.GroupContext;
@@ -36,6 +33,7 @@ import com.google.common.collect.Multimap;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -119,8 +117,10 @@ public class CobolVisitor extends CobolParserBaseVisitor<Void> {
             .variableUsages(collectVariableUsages(definedVariables))
             .paragraphDefinitions(groupContext.getParagraphDefinitions())
             .paragraphUsages(groupContext.getParagraphUsages())
+            .paragraphRanges(groupContext.getParagraphRanges())
             .sectionDefinitions(groupContext.getSectionDefinitions())
             .sectionUsages(groupContext.getSectionUsages())
+            .sectionRanges(groupContext.getSectionRanges())
             .constantDefinitions(constants.getDefinitions().asMap())
             .constantUsages(constants.getUsages().asMap())
             .copybookDefinitions(copybooks.getDefinitions().asMap())
@@ -228,6 +228,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<Void> {
   @Override
   public Void visitProcedureSection(ProcedureSectionContext ctx) {
     throwWarning(ctx.getStart());
+    addSectionRange(ctx);
     outlineTreeBuilder.addNode(ctx.getStart().getText(), NodeType.PROCEDURE_SECTION, ctx);
 
     String name = ctx.getStart().getText().toUpperCase();
@@ -239,8 +240,31 @@ public class CobolVisitor extends CobolParserBaseVisitor<Void> {
   @Override
   public Void visitParagraph(ParagraphContext ctx) {
     areaAWarning(ctx.getStart());
+    addParagraphRange(ctx);
+
     outlineTreeBuilder.addNode(ctx.getStart().getText(), NodeType.PROCEDURE, ctx);
     return visitChildren(ctx);
+  }
+
+  private void addSectionRange(ParserRuleContext ctx) {
+    String name = ctx.getStart().getText().toUpperCase();
+    getRange(ctx).ifPresent(range -> groupContext.addSectionRange(name, range));
+  }
+
+  private void addParagraphRange(ParserRuleContext ctx) {
+    String name = ctx.getStart().getText().toUpperCase();
+    getRange(ctx).ifPresent(range -> groupContext.addParagraphRange(name, range));
+  }
+
+  private Optional<Location> getRange(ParserRuleContext ctx) {
+    Optional<Locality> start = getLocality(ctx.getStart());
+    Optional<Locality> end = getLocality(ctx.getStop());
+
+    if (start.isPresent() && end.isPresent()) {
+      Range range = new Range(start.get().getRange().getStart(), end.get().getRange().getEnd());
+      return Optional.of(new Location(start.get().getUri(), range));
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/validations/AnalysisResult.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/validations/AnalysisResult.java
@@ -34,8 +34,10 @@ public class AnalysisResult {
   @Builder.Default Map<String, List<Location>> variableUsages = new HashMap<>();
   @Builder.Default Map<String, List<Location>> paragraphDefinitions = new HashMap<>();
   @Builder.Default Map<String, List<Location>> paragraphUsages = new HashMap<>();
+  @Builder.Default Map<String, List<Location>> paragraphRange = new HashMap<>();
   @Builder.Default Map<String, List<Location>> sectionDefinitions = new HashMap<>();
   @Builder.Default Map<String, List<Location>> sectionUsages = new HashMap<>();
+  @Builder.Default Map<String, List<Location>> sectionRange = new HashMap<>();
   @Builder.Default Map<String, List<Location>> constantDefinitions = new HashMap<>();
   @Builder.Default Map<String, List<Location>> constantUsages = new HashMap<>();
   @Builder.Default Map<String, List<Location>> copybookDefinitions = new HashMap<>();

--- a/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/validations/CobolLanguageEngineFacade.java
+++ b/server/src/main/java/com/broadcom/lsp/cobol/service/delegates/validations/CobolLanguageEngineFacade.java
@@ -85,18 +85,20 @@ public class CobolLanguageEngineFacade implements LanguageEngineFacade {
     return new AnalysisResult(
         collectDiagnosticsForAffectedDocuments(
             convertErrors(result.getErrors()), context.getCopybookDefinitions(), uri),
-        convertLocations(context.getVariableDefinitions()),
-        convertLocations(context.getVariableUsages()),
-        convertLocations(context.getParagraphDefinitions()),
-        convertLocations(context.getParagraphUsages()),
-        convertLocations(context.getSectionDefinitions()),
-        convertLocations(context.getSectionUsages()),
-        convertLocations(context.getConstantDefinitions()),
-        convertLocations(context.getConstantUsages()),
-        convertLocations(context.getCopybookDefinitions()),
-        convertLocations(context.getCopybookUsages()),
-        convertLocations(context.getSubroutinesDefinitions()),
-        convertLocations(context.getSubroutinesUsages()),
+        convertEntities(context.getVariableDefinitions()),
+        convertEntities(context.getVariableUsages()),
+        convertEntities(context.getParagraphDefinitions()),
+        convertEntities(context.getParagraphUsages()),
+        convertEntities(context.getParagraphRanges()),
+        convertEntities(context.getSectionDefinitions()),
+        convertEntities(context.getSectionUsages()),
+        convertEntities(context.getSectionRanges()),
+        convertEntities(context.getConstantDefinitions()),
+        convertEntities(context.getConstantUsages()),
+        convertEntities(context.getCopybookDefinitions()),
+        convertEntities(context.getCopybookUsages()),
+        convertEntities(context.getSubroutinesDefinitions()),
+        convertEntities(context.getSubroutinesUsages()),
         context.getOutlineTree());
   }
 
@@ -148,7 +150,7 @@ public class CobolLanguageEngineFacade implements LanguageEngineFacade {
     return DiagnosticSeverity.forValue(severity.ordinal() + 1);
   }
 
-  private Map<String, List<Location>> convertLocations(Map<String, Collection<Location>> source) {
+  private <T> Map<String, List<T>> convertEntities(Map<String, Collection<T>> source) {
     return source.entrySet().stream()
         .collect(toMap(Map.Entry::getKey, it -> new ArrayList<>(it.getValue())));
   }

--- a/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/GroupContextTest.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/core/semantics/GroupContextTest.java
@@ -75,6 +75,29 @@ class GroupContextTest {
     assertEquals(0, groupContext.generateParagraphErrors(messageService).size());
   }
 
+  @Test
+  void testParagraphRange() {
+    Location location = mock(Location.class);
+    GroupContext context = new GroupContext();
+    context.addParagraphRange("test_paragraph", location);
+    checkRange(context.getParagraphRanges(), "test_paragraph", location);
+  }
+
+  @Test
+  void testSectionRange() {
+    Location location = mock(Location.class);
+    GroupContext context = new GroupContext();
+    context.addSectionRange("test_section", location);
+    checkRange(context.getSectionRanges(), "test_section", location);
+  }
+
+  private void checkRange(Map<String, Collection<Location>> map, String name, Location expected) {
+    assertEquals(1, map.size());
+
+    Location range = map.get(name).iterator().next();
+    assertEquals(expected, range);
+  }
+
   private GroupContext prepareGroup(Locality locality) {
     GroupContext context = new GroupContext();
     context.addCandidateUsage("test", locality);
@@ -89,5 +112,4 @@ class GroupContextTest {
     Location actualLocation = usages.get("test").iterator().next();
     assertEquals(expectedLocation, actualLocation);
   }
-
 }

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphRange.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestParagraphRange.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package com.broadcom.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cobol.service.CopybookProcessingMode;
+import com.broadcom.lsp.cobol.service.delegates.validations.AnalysisResult;
+import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** This test checks that performing defined paragraph processed with correct paragraph range */
+class TestParagraphRange {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "          PROGRAM-ID. TEST1.\n"
+          + "          DATA DIVISION.\n"
+          + "          WORKING-STORAGE SECTION.\n"
+          + "          PROCEDURE DIVISION.\n"
+          + "            PERFORM {#GET-DATA}.\n"
+          + "            STOP RUN.\n"
+          + "          {#*GET-DATA}.\n"
+          + "            DISPLAY \"\".\n"
+          + "            DISPLAY \"\".\n"
+          + "            DISPLAY \"\".\n"
+          + "            DISPLAY \"\".";
+
+  @Test
+  void test() {
+      AnalysisResult analysisResult = UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(), ImmutableList.of(), CopybookProcessingMode.ENABLED);
+      Map<String, List<Location>> ranges = analysisResult.getParagraphRange();
+      assertThat(ranges.size(), equalTo(1));
+
+      Location location = ranges.get("GET-DATA").get(0);
+      assertEquals(new Position(7, 10), location.getRange().getStart());
+      assertEquals(new Position(11, 23), location.getRange().getEnd());
+  }
+
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSectionRange.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/TestSectionRange.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package com.broadcom.lsp.cobol.usecases;
+
+import com.broadcom.lsp.cobol.service.CopybookProcessingMode;
+import com.broadcom.lsp.cobol.service.delegates.validations.AnalysisResult;
+import com.broadcom.lsp.cobol.usecases.engine.UseCaseEngine;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** This test checks that performing defined section processed with correct section range */
+class TestSectionRange {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "          PROGRAM-ID. TEST1.\n"
+          + "          DATA DIVISION.\n"
+          + "          WORKING-STORAGE SECTION.\n"
+          + "          PROCEDURE DIVISION.\n"
+          + "            PERFORM {@GET-DATA}.\n"
+          + "            STOP RUN.\n"
+          + "          {@*GET-DATA} SECTION.\n"
+          + "            DISPLAY \"\".\n"
+          + "            DISPLAY \"\".\n"
+          + "            DISPLAY \"\".";
+
+  @Test
+  void test() {
+      AnalysisResult analysisResult = UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(), ImmutableList.of(), CopybookProcessingMode.ENABLED);
+      Map<String, List<Location>> ranges = analysisResult.getSectionRange();
+      assertThat(ranges.size(), equalTo(1));
+
+      Location location = ranges.get("GET-DATA").get(0);
+      assertEquals(new Position(7, 10), location.getRange().getStart());
+      assertEquals(new Position(10, 23), location.getRange().getEnd());
+  }
+
+}

--- a/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCaseEngine.java
+++ b/server/src/test/java/com/broadcom/lsp/cobol/usecases/engine/UseCaseEngine.java
@@ -159,8 +159,9 @@ public class UseCaseEngine {
    *     document or copybooks. IDs are the same as in the diagnostic sections inside the text.
    * @param subroutineNames - list of subroutine names used in the document
    * @param processingMode - copybook processing mode
+   * @return analysis result object
    */
-  public void runTest(
+  public AnalysisResult runTest(
       String text,
       List<CobolText> copybooks,
       Map<String, Diagnostic> expectedDiagnostics,
@@ -174,6 +175,7 @@ public class UseCaseEngine {
         .subroutineDefinitions(makeSubroutinesDefinitions(subroutineNames))
         .build();
     assertResultEquals(actual, expected);
+    return actual;
   }
 
   private Map<String, List<Location>> makeSubroutinesDefinitions(List<String> subroutineNames) {


### PR DESCRIPTION
To build the CCF graph we need to have ranges of paragraphs and sections to check the usages belongs to the paragraph or to the section.

- 2 fields to the result added
- unit tests added
- use case tests added
