### PR TITLE
build: Add husky config file to the root

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}


### PR DESCRIPTION
Husky install git hooks it comes from UI tests.
Without husky config
pre-commit hook fails and you can't commit anything.