### PR TITLE
Describe new local copybook features in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,15 @@ You can store your copybooks locally in folders in your workspace and specify th
 
 1. Open the **Extensions** tab, click the cog icon next to **COBOL Language Support** and select **Extension Settings** to open the COBOL Language Support extension settings. 
 2. Switch from **User** to **Workspace**.
-3. Under **Cpy-manager: Paths-local**, specify the paths of the folders containing copybooks. Ensure that you specify relative paths to the workspace root. Absolute paths are not supported.  
-   - **Tip:** To obtain the relative path of a folder in your workspace, right-click it in the folder tree and select **Copy Relative Path**.
+3. Under **Cpy-manager: Paths-local**, specify the paths of the folders containing copybooks.
+   - **Tip:** We recommend that you specify relative paths from the workspace root. To obtain the relative path of a folder in your workspace, right-click it in the folder tree and select **Copy Relative Path**. 
    - The folders are searched in the order they are listed. If two folders contain a copybook with the same file name, the one from the folder higher on the list is used.
 4. Open a program or project.  
    Copybook support features are now enabled.
+   
+If you specify your copybook folders using absolute paths or paths containing `/..` or `/.`, the copybook folders are not watched for changes. You might need to resolve names of recently added copybooks in your code manually. 
+
+To resolve copybook names manually, hover over the copybook name with the error underline, select **Quick Fix...** and **Resolve copybook**.
 
 ### Retrieving Copybooks from the Mainframe
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can store your copybooks locally in folders in your workspace and specify th
 4. Open a program or project.  
    Copybook support features are now enabled.
    
-If you specify your copybook folders using absolute paths or paths containing `/..` or `/.`, the copybook folders are not watched for changes. You might need to resolve names of recently added copybooks in your code manually. 
+If you specify your copybook folders using absolute paths or paths containing `../` or `./`, the copybook folders are not watched for changes. You might need to resolve names of recently added copybooks in your code manually. 
 
 To resolve copybook names manually, hover over the copybook name with the error underline, select **Quick Fix...** and **Resolve copybook**.
 


### PR DESCRIPTION
This is the doc change for US727864. I have removed the line saying relative paths are required but kept it as a recommendation due to the folders not being monitored for changes otherwise.

I have added info on how to resolve copybook names manually.

Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>