### PR TITLE
feature: US729486 Extend LSP API #785

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/domain/event/model/AnalysisResultEvent.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/domain/event/model/AnalysisResultEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.domain.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * This class represents a client event object that client sends to the server
+ * to retrieve analysis result
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnalysisResultEvent {
+  @NonNull
+  private String uri;
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiService.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.service;
+
+import com.google.gson.JsonObject;
+import lombok.NonNull;
+import org.eclipse.lsp.cobol.service.delegates.validations.AnalysisResult;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
+
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * This interface describes endpoints for extended API
+ */
+@JsonSegment("extended")
+public interface ExtendedApiService {
+  /**
+   * Processes client request
+   * @param json represents the request object in the json format
+   * @return Future object with retrieved analysis result
+  */
+  @JsonRequest
+  CompletableFuture<AnalysisResult> analysis(@NonNull JsonObject json);
+}


### PR DESCRIPTION
Custom LSP implementation should support external calls.
This is needed to extend plugin functionality and plugins interaction.

Signed-off-by: Leonid Baranov <leonid.baranov@broadcom.com>