### PR TITLE
fix: coloring for divisions

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -9,7 +9,8 @@
         { "include": "#picture" },
         { "include": "#sql-block" },
         { "include": "#cobol-keywords" },
-        { "include": "#common-cobol-keywords" }
+        { "include": "#common-cobol-keywords" },
+        { "include": "#db2-sql-keywords" }
     ],
     "repository": {
         "comment-line": {


### PR DESCRIPTION
The whole division is colored. E.g. two words in "Data Division".

Closes #796
