### PR TITLE
fix: Add color to hover message

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHover.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHover.java
@@ -54,7 +54,8 @@ public class VariableHover implements HoverProvider {
     for (String childLine: childrenDescriptions(variable))
       lines.add(prefix + childLine);
     return new Hover(ImmutableList.of(Either.forRight(
-        new MarkedString("COBOL", String.join("\n", lines)))));
+        // Hover coloring didn't work if the language is "COBOL" (our language ID)
+        new MarkedString("cobol", String.join("\n", lines)))));
   }
 
   private static Variable findVariableByPosition(Collection<Variable> variables, TextDocumentPositionParams position) {

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
@@ -73,7 +73,7 @@ class VariableHoverTest {
     Hover hover = variableHover.getHover(model, position5and5);
     assertNotNull(hover);
     MarkedString markedString = hover.getContents().getLeft().get(0).getRight();
-    assertEquals("COBOL", markedString.getLanguage());
+    assertEquals("cobol", markedString.getLanguage());
     assertEquals("01 TEST PIC 9.", markedString.getValue());
   }
 
@@ -101,7 +101,7 @@ class VariableHoverTest {
     Hover hover = variableHover.getHover(model, position5and5);
     assertNotNull(hover);
     MarkedString markedString = hover.getContents().getLeft().get(0).getRight();
-    assertEquals("COBOL", markedString.getLanguage());
+    assertEquals("cobol", markedString.getLanguage());
     assertEquals(result, markedString.getValue());
   }
 


### PR DESCRIPTION
For some reason, the coloring didn't work if I specify "COBOL" as language.