### PR TITLE
fix: Make extended API call result serializable #823

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
@@ -260,13 +260,19 @@ public class CobolTextDocumentService
 
   @Override
   @CheckServerShutdownState
-  public CompletableFuture<AnalysisResult> analysis(@NonNull JsonObject json) {
+  public CompletableFuture<ExtendedApiResult> analysis(@NonNull JsonObject json) {
     AnalysisResultEvent event = new Gson().fromJson(json.toString(), AnalysisResultEvent.class);
     String uri = Optional.ofNullable(event).map(AnalysisResultEvent::getUri).orElse("");
     return CompletableFuture.supplyAsync(
             () ->
                 Optional.ofNullable(docs.get(uri))
                     .map(CobolDocumentModel::getAnalysisResult)
+                    .map(ar -> new ExtendedApiResult(ar.getParagraphDefinitions(),
+                        ar.getParagraphUsages(),
+                        ar.getParagraphRange(),
+                        ar.getSectionDefinitions(),
+                        ar.getSectionUsages(),
+                        ar.getSectionRange()))
                     .orElse(null),
             executors.getThreadPoolExecutor())
         .whenComplete(

--- a/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiResult.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.service;
+
+import lombok.Value;
+import org.eclipse.lsp4j.Location;
+
+import java.util.*;
+
+/**
+ * Analysis result for Extended Api call
+ */
+@Value
+public class ExtendedApiResult {
+  Map<String, List<Location>> paragraphDefinitions;
+  Map<String, List<Location>> paragraphUsages;
+  Map<String, List<Location>> paragraphRange;
+  Map<String, List<Location>> sectionDefinitions;
+  Map<String, List<Location>> sectionUsages;
+  Map<String, List<Location>> sectionRange;
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiService.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/service/ExtendedApiService.java
@@ -17,7 +17,6 @@ package org.eclipse.lsp.cobol.service;
 
 import com.google.gson.JsonObject;
 import lombok.NonNull;
-import org.eclipse.lsp.cobol.service.delegates.validations.AnalysisResult;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
@@ -35,5 +34,5 @@ public interface ExtendedApiService {
    * @return Future object with retrieved analysis result
   */
   @JsonRequest
-  CompletableFuture<AnalysisResult> analysis(@NonNull JsonObject json);
+  CompletableFuture<ExtendedApiResult> analysis(@NonNull JsonObject json);
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -344,7 +344,7 @@ class CobolTextDocumentServiceTest extends MockTextDocumentService {
     JsonObject json = new JsonObject();
     json.add("uri", new JsonPrimitive(UseCaseUtils.DOCUMENT_URI));
 
-    AnalysisResult result = service.analysis(json).get();
+    ExtendedApiResult result = service.analysis(json).get();
     assertNotNull(result);
   }
 


### PR DESCRIPTION
AnalysysResult is not serializable anymore and cannot be used as a result of the extended API call

Signed-off-by: Leonid Baranov <leonid.baranov@broadcom.com>