### PR TITLE
refactor: change java unit tests to use only one thread

### DIFF
--- a/server/src/test/java/org/eclipse/lsp/cobol/service/mocks/MockTextDocumentService.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/mocks/MockTextDocumentService.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp.cobol.service.delegates.formations.Formations;
 import org.eclipse.lsp.cobol.service.delegates.references.Occurrences;
 import org.eclipse.lsp.cobol.service.delegates.validations.LanguageEngineFacade;
 import org.eclipse.lsp.cobol.service.utils.CustomThreadPoolExecutorService;
+import org.eclipse.lsp.cobol.service.utils.TestThreadPoolExecutor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,8 +41,28 @@ public class MockTextDocumentService {
   @Mock protected Occurrences occurrences;
   @Mock protected Formations formations;
 
-  /** Give a dummy {@link CobolTextDocumentService} with mocked attributes for testing. */
-  protected CobolTextDocumentService getMockedTextDocumentService() {
+  /**
+   * Give a dummy {@link CobolTextDocumentService} with mocked attributes for testing.
+   * All tasks run synchronously.
+   */
+  protected CobolTextDocumentService getMockedTextDocumentServiceUsingSameThread() {
+    return CobolTextDocumentService.builder()
+        .communications(communications)
+        .engine(engine)
+        .dataBus(broker)
+        .completions(completions)
+        .actions(actions)
+        .occurrences(occurrences)
+        .formations(formations)
+        .executors(new TestThreadPoolExecutor())
+        .build();
+  }
+
+  /**
+   * Give a dummy {@link CobolTextDocumentService} with mocked attributes for testing.
+   * Tasks run in the separate thread.
+   */
+  protected CobolTextDocumentService getMockedTextDocumentServiceUsingSeparateThread() {
     return CobolTextDocumentService.builder()
         .communications(communications)
         .engine(engine)

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/utils/TestThreadPoolExecutor.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/utils/TestThreadPoolExecutor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.service.utils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * The {@link CustomThreadPoolExecutor} implementation for run everything in main thread.
+ */
+public class TestThreadPoolExecutor implements CustomThreadPoolExecutor {
+  private static final ScheduledExecutorService EXECUTOR_SERVICE = new TestExecutorService();
+
+  @Override
+  public ExecutorService getThreadPoolExecutor() {
+    return EXECUTOR_SERVICE;
+  }
+
+  @Override
+  public ScheduledExecutorService getScheduledThreadPoolExecutor() {
+    return EXECUTOR_SERVICE;
+  }
+
+  private static class TestExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+      return false;
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+      runnable.run();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable runnable, long l, TimeUnit timeUnit) {
+      return new TestScheduledFuture<>(submit(runnable));
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long l, TimeUnit timeUnit) {
+      return new TestScheduledFuture<>(submit(callable));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+      return new TestScheduledFuture<>(submit(runnable));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) {
+      return new TestScheduledFuture<>(submit(runnable));
+    }
+  }
+
+  private static final class TestScheduledFuture<V> implements ScheduledFuture<V> {
+
+    private final Future<V> future;
+
+    private TestScheduledFuture(Future<V> future) {
+      this.future = future;
+    }
+
+    @Override
+    public long getDelay(TimeUnit timeUnit) {
+      return 0;
+    }
+
+    @Override
+    public int compareTo(Delayed delayed) {
+      return 0;
+    }
+
+    @Override
+    public boolean cancel(boolean b) {
+      return future.cancel(b);
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return future.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+      return future.isDone();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+      return future.get();
+    }
+
+    @Override
+    public V get(long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+      return future.get(l, timeUnit);
+    }
+  }
+}

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/utils/TestThreadPoolExecutorTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/utils/TestThreadPoolExecutorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.service.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test {@link TestThreadPoolExecutor}
+ */
+class TestThreadPoolExecutorTest {
+  private static final int THE_MAGIC_NUMBER = 42;
+
+  @Test
+  void testExecutor() {
+    CustomThreadPoolExecutor customThreadPoolExecutor = new TestThreadPoolExecutor();
+    TestTask task = new TestTask();
+    assertFalse(task.isDone());
+    customThreadPoolExecutor.getThreadPoolExecutor().submit(task);
+    assertTrue(task.isDone());
+  }
+
+  @Test
+  void testSchedule() throws ExecutionException, InterruptedException {
+    CustomThreadPoolExecutor customThreadPoolExecutor = new TestThreadPoolExecutor();
+    TestTask task = new TestTask();
+    assertFalse(task.isDone());
+    Future<Integer> result = customThreadPoolExecutor.getScheduledThreadPoolExecutor()
+        // schedule it for 10 days
+        .schedule(task::getMagicNumber, 10, TimeUnit.DAYS);
+    // it's done!
+    assertTrue(task.isDone());
+    assertEquals(42, result.get());
+  }
+
+  private static class TestTask implements Runnable {
+    private boolean done = false;
+
+    @Override
+    public void run() {
+      done = true;
+    }
+
+    public Integer getMagicNumber() {
+      done = true;
+      return THE_MAGIC_NUMBER;
+    }
+
+    public boolean isDone() {
+      return done;
+    }
+  }
+}


### PR DESCRIPTION
Add TestThreadPoolExecutor to be able to run test syncronously.

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>