### PR TITLE
test: Add Zowe test suite

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -24,6 +24,9 @@ cypress-tests-report*
 .vscode
 .theia
 statistics.txt
+*_meta.yaml
+ssh 
+tso 
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ If you are using VS Code, you can reload the window. Go to `View > Command Palet
 Beside the workpsace loading, also we need to mount the `test` folder in order to run `TC318696`. 
   #### Run Theia in docker:
 
-  <code>sudo docker run -it --rm -p 3000:3000 -v /home/$USER/$project/plugins/:/home/theia/plugins -v /home/$USER/che-che4z-lsp-for-cobol/tests/test_files/project/:/home/project -v /home/$USER/che-che4z-lsp-for-cobol/tests/test_files/test:/home/test --name theia theiaide/theia-{java or full}:1.5.0</code>
+  <code>sudo docker run -it --rm -p 3000:3000 -v /home/$USER/$project/plugins/:/home/theia/plugins -v /home/$USER/che-che4z-lsp-for-cobol/tests/test_files/project/:/home/project -v /home/$USER/che-che4z-lsp-for-cobol/tests/test_files/test:/home/test --name theia theiaide/theia-{java or full}:1.5.0 -v  /home/$USER/che-che4z-lsp-for-cobol/tests/test_files/zowe:/home/theia/.zowe </code>
 
   OR
 

--- a/tests/cypress/integration/LSP/zowe.spec.js
+++ b/tests/cypress/integration/LSP/zowe.spec.js
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+
+ * SPDX-License-Identifier: EPL-2.0
+
+ * Contributors:
+ *  Broadcom, Inc. - initial API and implementation
+ */
+
+/// <reference types="Cypress" />
+
+//@ts-ignore
+/// <reference types="../../support/" />
+
+context('This is a Zowe integration spec file', () => {
+  /* Variables Panel */
+  const basePath = 'test_files/project/.c4z/.copybooks/local/CLIST/';
+  const TEST = basePath + 'TEST.cpy';
+  const ASTRO = basePath + 'ASTRO.cpy';
+  const FOO = basePath + 'FOO.cpy';
+  const NOTFOUND = basePath + 'NOTFOUND.cpy';
+  const NOTFOUND_NESTED = basePath + 'COPYNF.cpy';
+  const ERR = basePath + 'ERR';
+
+  /* Functions Panel */
+  function getHoverMessage(line, message) {
+    return cy.goToLine(line).getCurrentLineErrors({ expectedLine: line }).getHoverErrorMessage().contains(message);
+  }
+
+  function addCopybookAndgetHoverMessage(line, copybook, message) {
+    return cy
+      .getLineByNumber(48)
+      .type(`{end}{enter}             COPY ${copybook}.`)
+      .goToLine(line)
+      .getCurrentLineErrors({ expectedLine: line })
+      .getHoverErrorMessage()
+      .contains(message);
+  }
+
+  function popupMsg(message) {
+    return cy.get('.theia-notification-list-item-content').should('contain', message);
+  }
+
+  function resolveCopybook(line, text) {
+    return cy.getLineByNumber(line).findText(text).click().type('{ctrl}.').get('.p-Menu-itemLabel').eq(0).click();
+  }
+
+  describe('TC219568 Copybook is (semi) automatically downloaded', () => {
+    it(['zowe'], 'Checks that copybook was downloaded', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'TEST', 'TEST: Copybook not found');
+      cy.task('isFileExists', TEST).should('be.false');
+      cy.updateConfigs('clist_local');
+      getHoverMessage(49, 'TEST: Copybook not found');
+      cy.task('isFileExists', TEST).should('be.true');
+    });
+  });
+
+  describe('TC219569 Nested Copybook is (semi) automatically downloaded', () => {
+    it(['zowe'], 'Checks that nested copybooks were downloaded', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'ASTRO', 'ASTRO: Copybook not found');
+
+      cy.updateConfigs('clist_local');
+
+      resolveCopybook(49, 'ASTRO');
+      popupMsg('Fetching copybooks');
+
+      cy.task('isFileExists', ASTRO).should('be.true');
+      // FOO member has a 5s delay
+      cy.wait(6000).task('isFileExists', FOO).should('be.true');
+    });
+  });
+
+  describe('TC219570 Nested Copybook is (semi) automatically downloaded', () => {
+    it(['zowe'], 'Cobol file has a syntax error in case copybook is missing ', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'NOTFOUND', 'NOTFOUND: Copybook not found');
+      cy.updateConfigs('clist_local');
+      resolveCopybook(49, 'NOTFOUND');
+      popupMsg('Missing copybooks: NOTFOUND');
+      cy.task('isFileExists', NOTFOUND).should('be.false');
+    });
+  });
+
+  describe('TC219571 Cobol file has a syntax error in case nested copybook is missing ', () => {
+    it(['zowe'], 'Checks nested copybook missing', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'COPYNF', 'COPYNF: Copybook not found');
+
+      cy.updateConfigs('clist_local');
+
+      resolveCopybook(49, 'COPYNF');
+
+      cy.task('isFileExists', NOTFOUND_NESTED).should('be.true');
+      cy.task('isFileExists', NOTFOUND).should('be.false');
+    });
+  });
+
+  describe('TC312870 Wrong profile credentials - one profile ', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_wrongpass');
+    });
+    it(['zowe'], 'Wrong profile credentials - one profile', () => {
+      cy.openFile('HOVER.CBL');
+
+      addCopybookAndgetHoverMessage(49, 'NOTFOUND', 'NOTFOUND: Copybook not found');
+
+      resolveCopybook(49, 'NOTFOUND');
+      popupMsg('Missing copybooks: NOTFOUND');
+
+      getHoverMessage(49, 'NOTFOUND: Copybook not found');
+      resolveCopybook(49, 'NOTFOUND');
+
+      popupMsg(
+        'Invalid credentials for profile: wrongPass. Copybook retrieval is blocked. Ensure the profile contains correct credentials.',
+      )
+        .get('.theia-button')
+        .contains('Unblock and retry')
+        .click();
+
+      popupMsg('Missing copybooks: NOTFOUND');
+
+      cy.task('isFileExists', NOTFOUND).should('be.false');
+    });
+  });
+
+  describe('TC312876 Wrong profile credentials - no password ', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_nopass');
+    });
+    it(['zowe'], 'Verify that server detects a no Pass credential response.', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'ASTRO', 'ASTRO: Copybook not found');
+      resolveCopybook(49, 'ASTRO');
+      popupMsg('No password in Zowe profile noPass.');
+
+      cy.task('isFileExists', ASTRO).should('be.false');
+
+      cy.updateConfigs('clist_local');
+      resolveCopybook(49, 'ASTRO');
+      cy.task('isFileExists', ASTRO).should('be.true');
+    });
+  });
+
+  describe('TC312871 Wrong profile credentials - change to a valid profile', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_wrongpass');
+    });
+    it(['zowe'], 'Wrong profile credentials - change to a valid profile', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'ASTRO', 'ASTRO: Copybook not found').wait(500);
+      resolveCopybook(49, 'ASTRO');
+      popupMsg('Incorrect credentials in Zowe profile wrongPass.');
+
+      cy.task('isFileExists', ASTRO).should('be.false');
+
+      cy.updateConfigs('clist_local');
+      resolveCopybook(49, 'ASTRO');
+      cy.task('isFileExists', ASTRO).should('be.true');
+    });
+  });
+
+  describe('TC312877 Wrong profile credentials - change from invalid  profile to noPass and vice versa', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_wrongpass');
+    });
+    it(['zowe'], 'Wrong profile credentials - change from invalid  profile to noPass and vice versa', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'ASTRO', 'ASTRO: Copybook not found').wait(500);
+      resolveCopybook(49, 'ASTRO');
+      popupMsg('Incorrect credentials in Zowe profile wrongPass.');
+      cy.task('isFileExists', ASTRO).should('be.false');
+
+      cy.updateConfigs('clist_nopass');
+      getHoverMessage(49, 'ASTRO: Copybook not found');
+      resolveCopybook(49, 'ASTRO');
+      popupMsg('No password in Zowe profile noPass.');
+      cy.task('isFileExists', ASTRO).should('be.false');
+    });
+  });
+
+  describe('TC320158 Get 501 error', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_local');
+    });
+    it(['zowe'], 'Get 501 error', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'ERR', 'ERR: Copybook not found').wait(500);
+      resolveCopybook(49, 'ERR');
+      popupMsg('Error: Rest API failure with HTTP(S) status 501');
+      cy.task('isFileExists', ERR).should('be.false');
+    });
+  });
+
+  describe('TC219573 Nested Recursive Copybooks are downloaded and error is shown', () => {
+    beforeEach(() => {
+      cy.updateConfigs('clist_local');
+    });
+    it(['zowe'], 'Nested Recursive Copybooks are downloaded and error is shown', () => {
+      cy.openFile('HOVER.CBL');
+      addCopybookAndgetHoverMessage(49, 'RECUR1', 'RECUR1: Copybook not found').wait(500);
+      resolveCopybook(49, 'RECUR1');
+      resolveCopybook(49, 'RECUR1');
+      getHoverMessage(49, 'Recursive copybook declaration for: RECUR2');
+    });
+  });
+});

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -27,32 +27,32 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-import "@eclipse/che-che4z/tests";
+import '@eclipse/che-che4z/tests';
 
 const baseUrl = Cypress.config('baseUrl');
 
 const username = Cypress.env('username');
 const password = Cypress.env('password');
 
-  beforeEach(() => {
-    cy.task('deleteFile', 'test_files/project/.vscode/settings.json');
-    cy.task('deleteFile', 'test_files/project/.theia/settings.json');
-    cy.task('deleteFile', 'test_files/project/testing/BOOK3.cpy');
-    cy.task('deleteFile', 'test_files/project/.vscode/launch.json');
-    cy.task('deleteFile', 'test_files/project/.theia/launch.json');
-    cy.task('deleteFile', 'test_files/project/.copybooks/zowe-profile-1/DATA.SET.PATH2/BOOK3.cpy');
-    cy.task('deleteFile', 'test_files/project/s.cbl');
-    cy.visit('/', {
-      onBeforeLoad: (win) => {
-        win.sessionStorage.clear();
-      },
-    });
-    cy.clearCookies();
-    cy.clearLocalStorage();
-    cy.waitForAppStart();
-    cy.openFileExplorer();
+beforeEach(() => {
+  cy.task('deleteFile', 'test_files/project/.vscode/settings.json');
+  cy.task('deleteFile', 'test_files/project/.theia/settings.json');
+  cy.task('deleteFile', 'test_files/project/testing/BOOK3.cpy');
+  cy.task('deleteFile', 'test_files/project/.vscode/launch.json');
+  cy.task('deleteFile', 'test_files/project/.theia/launch.json');
+  cy.task('deleteFile', 'test_files/project/.copybooks/zowe-profile-1/DATA.SET.PATH2/BOOK3.cpy');
+  cy.task('deleteFile', 'test_files/project/s.cbl');
+  cy.task('deleteFile', 'test_files/project/.c4z/.copybooks');
+  cy.visit('/', {
+    onBeforeLoad: (win) => {
+      win.sessionStorage.clear();
+    },
   });
-
+  cy.clearCookies();
+  cy.clearLocalStorage();
+  cy.waitForAppStart();
+  cy.openFileExplorer();
+});
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from

--- a/tests/test_files/project/settings/clist_local.json
+++ b/tests/test_files/project/settings/clist_local.json
@@ -1,0 +1,4 @@
+{
+    "cobol-lsp.cpy-manager.profiles": "local",
+    "cobol-lsp.cpy-manager.paths-dsn": ["CLIST"]
+}

--- a/tests/test_files/project/settings/clist_nopass.json
+++ b/tests/test_files/project/settings/clist_nopass.json
@@ -1,0 +1,4 @@
+{
+    "cobol-lsp.cpy-manager.profiles": "noPass",
+    "cobol-lsp.cpy-manager.paths-dsn": ["CLIST"]
+}

--- a/tests/test_files/project/settings/clist_wrongpass.json
+++ b/tests/test_files/project/settings/clist_wrongpass.json
@@ -1,0 +1,4 @@
+{
+    "cobol-lsp.cpy-manager.profiles": "wrongPass",
+    "cobol-lsp.cpy-manager.paths-dsn": ["CLIST"]
+}

--- a/tests/test_files/zowe/profiles/zosmf/local.yaml
+++ b/tests/test_files/zowe/profiles/zosmf/local.yaml
@@ -1,0 +1,8 @@
+host: zowe
+protocol: http
+port: 8080
+user: foo
+password: bar
+rejectUnauthorized: false
+encoding: 0
+responseTimeout: 0

--- a/tests/test_files/zowe/profiles/zosmf/noPass.yaml
+++ b/tests/test_files/zowe/profiles/zosmf/noPass.yaml
@@ -1,0 +1,8 @@
+host: zowe
+protocol: http
+port: 8080
+user: foo
+password: ""
+rejectUnauthorized: false
+encoding: 0
+responseTimeout: 0

--- a/tests/test_files/zowe/profiles/zosmf/wrongPass.yaml
+++ b/tests/test_files/zowe/profiles/zosmf/wrongPass.yaml
@@ -1,0 +1,8 @@
+host: zowe
+protocol: http
+port: 8080
+user: foo
+password: foo
+rejectUnauthorized: false
+encoding: 0
+responseTimeout: 0

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -17,9 +17,9 @@
     "@babel/highlight" "^7.12.13"
 
 "@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.8":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.8.tgz#5b783b9808f15cef71547f1b691f34f8ff6003a6"
-  integrity sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.11.tgz#9c8fe523c206979c9a81b1e12fe50c1254f1aa35"
+  integrity sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==
 
 "@babel/core@7.4.5":
   version "7.4.5"
@@ -42,16 +42,16 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.12.1":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.8.tgz#c191d9c5871788a591d69ea1dc03e5843a3680fb"
-  integrity sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.10.tgz#07de050bbd8193fcd8a3c27918c0890613a94559"
+  integrity sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.0"
-    "@babel/helper-compilation-targets" "^7.13.8"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-compilation-targets" "^7.13.10"
     "@babel/helper-module-transforms" "^7.13.0"
-    "@babel/helpers" "^7.13.0"
-    "@babel/parser" "^7.13.4"
+    "@babel/helpers" "^7.13.10"
+    "@babel/parser" "^7.13.10"
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
@@ -63,7 +63,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.13.0", "@babel/generator@^7.4.4":
+"@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.4.4":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
   integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
@@ -87,10 +87,10 @@
     "@babel/helper-explode-assignable-expression" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.8":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz#02bdb22783439afb11b2f009814bdd88384bd468"
-  integrity sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.10", "@babel/helper-compilation-targets@^7.13.8":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz#1310a1678cb8427c07a753750da4f8ce442bdd0c"
+  integrity sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
   dependencies:
     "@babel/compat-data" "^7.13.8"
     "@babel/helper-validator-option" "^7.12.17"
@@ -98,9 +98,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.3.0":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.8.tgz#0367bd0a7505156ce018ca464f7ac91ba58c1a04"
-  integrity sha512-qioaRrKHQbn4hkRKDHbnuQ6kAxmmOF+kzKGnIfxPK4j2rckSJCpKzr/SSTlohSCiE3uAQpNDJ9FIh4baeE8W+w==
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz#30d30a005bca2c953f5653fc25091a492177f4f6"
+  integrity sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==
   dependencies:
     "@babel/helper-function-name" "^7.12.13"
     "@babel/helper-member-expression-to-functions" "^7.13.0"
@@ -262,28 +262,28 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/helpers@^7.13.0", "@babel/helpers@^7.4.4":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.0.tgz#7647ae57377b4f0408bf4f8a7af01c42e41badc0"
-  integrity sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==
+"@babel/helpers@^7.13.10", "@babel/helpers@^7.4.4":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8"
+  integrity sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
   dependencies:
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
-  version "7.13.8"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.8.tgz#10b2dac78526424dfc1f47650d0e415dfd9dc481"
-  integrity sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.4", "@babel/parser@^7.4.5":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.9.tgz#ca34cb95e1c2dd126863a84465ae8ef66114be99"
-  integrity sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==
+"@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.4.5":
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
+  integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.13.8", "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.13.8"
@@ -846,12 +846,12 @@
     semver "^5.5.0"
 
 "@babel/preset-env@^7.12.1":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.9.tgz#3ee5f233316b10d066d7f379c6d1e13a96853654"
-  integrity sha512-mcsHUlh2rIhViqMG823JpscLMesRt3QbMsv1+jhopXEb3W2wXvQ9QoiOlZI9ZbR3XqPtaFpZwEZKYqGJnGMZTQ==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.10.tgz#b5cde31d5fe77ab2a6ab3d453b59041a1b3a5252"
+  integrity sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==
   dependencies:
     "@babel/compat-data" "^7.13.8"
-    "@babel/helper-compilation-targets" "^7.13.8"
+    "@babel/helper-compilation-targets" "^7.13.10"
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-validator-option" "^7.12.17"
     "@babel/plugin-proposal-async-generator-functions" "^7.13.8"
@@ -949,9 +949,9 @@
     regenerator-runtime "^0.12.0"
 
 "@babel/runtime@^7.8.4":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1067,7 +1067,7 @@
 
 "@eclipse/che-che4z@https://github.com/eclipse/che-che4z.git":
   version "0.0.0"
-  resolved "https://github.com/eclipse/che-che4z.git#e3968466b622205027fcf707b34af3b63d074412"
+  resolved "https://github.com/eclipse/che-che4z.git#f19b66de6e719bc0f8660f3e1702dbf4095f9d8b"
 
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
@@ -1107,9 +1107,9 @@
   integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
 
 "@types/node@^14.14.28":
-  version "14.14.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
-  integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1412,9 +1412,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^7.0.2:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.1.1.tgz#1e6b37a454021fa9941713f38b952fc1c8d32a84"
-  integrity sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.1.tgz#a5ac226171912447683524fa2f1248fcf8bac83d"
+  integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -2112,9 +2112,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001181:
-  version "1.0.30001194"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz#3d16ff3d734a5a7d9818402c28b1f636c5be5bed"
-  integrity sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==
+  version "1.0.30001202"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz#4cb3bd5e8a808e8cd89e4e66c549989bc8137201"
+  integrity sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2643,9 +2643,9 @@ cypress@6.4.0:
     yauzl "^2.10.0"
 
 cypress@^6.5.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.6.0.tgz#659c64cdb06e51b6be18fdac39d8f192deb54fa0"
-  integrity sha512-+Xx3Zn653LJHUsCb9h1Keql2jlazbr1ROmbY6DFJMmXKLgXP4ez9cE403W93JNGRbZK0Tng3R/oP8mvd9XAPVg==
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.7.1.tgz#6b8e1ba9badbded284ddc8575873b64211250ea6"
+  integrity sha512-MC9yt1GqpL4WVDQ0STI89K+PdLeC3T3NuAb2N61d6vYGR9pJy8w3Fqe0OWZwaRTJtg9eAyHXPGmFsyKeNQ3tmg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -2893,9 +2893,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.649:
-  version "1.3.678"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz#c7c6960463167126b7ed076fade14cac6223bfff"
-  integrity sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg==
+  version "1.3.689"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.689.tgz#0f4082467c109844b79a7b32a2649c9ab6a6c822"
+  integrity sha512-WCn+ZaU3V8WttlLNSOGOAlR2XpxibGre7slwGrYBB6oTjYPgP29LNDGG6wLvLTMseLdE+G1vno7PfY7JyDV48g==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3028,9 +3028,9 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.6.0:
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.21.0.tgz#4ecd5b8c5b44f5dedc9b8a110b01bbfeb15d1c83"
-  integrity sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.22.0.tgz#07ecc61052fec63661a2cab6bd507127c07adc6f"
+  integrity sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==
   dependencies:
     "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.4.0"
@@ -3049,7 +3049,7 @@ eslint@^7.6.0:
     file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^12.1.0"
+    globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -3057,7 +3057,7 @@ eslint@^7.6.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -3557,9 +3557,9 @@ glob-parent@^3.1.0:
     path-dirname "^1.0.0"
 
 glob-parent@^5.0.0, glob-parent@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -3593,6 +3593,13 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globals@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.6.0.tgz#d77138e53738567bb96a3916ff6f6b487af20ef7"
+  integrity sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==
+  dependencies:
+    type-fest "^0.20.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"
@@ -4019,9 +4026,9 @@ is-observable@^1.1.0:
     symbol-observable "^1.1.0"
 
 is-path-inside@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
-  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
@@ -4337,9 +4344,9 @@ listr-verbose-renderer@^0.5.0:
     figures "^2.0.0"
 
 listr2@^3.2.2:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.3.4.tgz#bca480e784877330b9d96d6cdc613ad243332e20"
-  integrity sha512-b0lhLAvXSr63AtPF9Dgn6tyxm8Kiz6JXpVGM0uZJdnDcZp02jt7FehgAnMfA9R7riQimOKjQgLknBTdz2nmXwQ==
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.4.3.tgz#543bcf849d5ffc70602708b69d2daac73f751699"
+  integrity sha512-wZmkzNiuinOfwrGqAwTCcPw6aKQGTAMGXwG5xeU1WpDjJNeBA35jGBeWxR3OF+R6Yl5Y3dRG+3vE8t6PDcSNHA==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -4451,7 +4458,7 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4690,9 +4697,9 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4:
     minimist "^1.2.5"
 
 mocha@>=7:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.0.tgz#a83a7432d382ae1ca29686062d7fdc2c36f63fe5"
-  integrity sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
+  integrity sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
@@ -6330,9 +6337,9 @@ tough-cookie@~2.5.0:
     punycode "^2.1.1"
 
 ts-loader@^8.0.6:
-  version "8.0.17"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.17.tgz#98f2ccff9130074f4079fd89b946b4c637b1f2fc"
-  integrity sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==
+  version "8.0.18"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.18.tgz#b2385cbe81c34ad9f997915129cdde3ad92a61ea"
+  integrity sha512-hRZzkydPX30XkLaQwJTDcWDoxZHK6IrEMDQpNd7tgcakFruFkeUp/aY+9hBb7BUGb+ZWKI0jiOGMo0MckwzdDQ==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"
@@ -6346,9 +6353,9 @@ tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsutils@^3.17.1:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.20.0.tgz#ea03ea45462e146b53d70ce0893de453ff24f698"
-  integrity sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 
@@ -6386,6 +6393,11 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -6397,9 +6409,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.0.3:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 umd@^3.0.0:
   version "3.0.3"
@@ -6559,9 +6571,9 @@ uuid@^8.3.2:
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
-  integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 validator@^10.11.0:
   version "10.11.0"
@@ -6775,9 +6787,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
-  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@20.2.4:
   version "20.2.4"
@@ -6801,9 +6813,9 @@ yargs-parser@^18.1.2:
     decamelize "^1.2.0"
 
 yargs-parser@^20.2.2:
-  version "20.2.6"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.6.tgz#69f920addf61aafc0b8b89002f5d66e28f2d8b20"
-  integrity sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## How to test
You need to mount the `zowe` folder
```
che-che4z-lsp-for-cobol/tests/test_files/zowe:/home/theia/.zowe
```
Then simply run the suite
```
npm run cy:run -- --config baseUrl=https://theia --spec cypress/integration/LSP/zowe.spec.js -b chrome --headless
```

## Results
```
  This is a Zowe integration spec file
    TC219568 Copybook is (semi) automatically downloaded
      √ Checks that copybook was downloaded (9384ms)
    TC219569 Nested Copybook is (semi) automatically downloaded
      √ Checks that nested copybooks were downloaded (15042ms)
    TC219570 Nested Copybook is (semi) automatically downloaded
      √ Cobol file has a syntax error in case copybook is missing  (18179ms)
    TC219571 Cobol file has a syntax error in case nested copybook is missing
      √ Checks nested copybook missing (8914ms)
    TC312870 Wrong profile credentials - one profile
      √ Wrong profile credentials - one profile (13802ms)
    TC312876 Wrong profile credentials - no password
      √ Verify that server detects a no Pass credential response. (12891ms)
    TC312871 Wrong profile credentials - change to a valid profile
      √ Wrong profile credentials - change to a valid profile (10932ms)
    TC312877 Wrong profile credentials - change from invalid  profile to noPass and vice versa
      √ Wrong profile credentials - change from invalid  profile to noPass and vice versa (16152ms)
    TC320158 Get 501 error
      √ Get 501 error (13043ms)
    TC219573 Nested Recursive Copybooks are downloaded and error is shown
      √ Nested Recursive Copybooks are downloaded and error is shown (18926ms)


  10 passing (4m)
```

Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>