### PR TITLE
fix: correct variable definition error processing for multy context case

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
@@ -32,6 +32,7 @@ import org.eclipse.lsp.cobol.core.model.ExtendedDocument;
 import org.eclipse.lsp.cobol.core.model.Locality;
 import org.eclipse.lsp.cobol.core.model.ResultWithErrors;
 import org.eclipse.lsp.cobol.core.model.SyntaxError;
+import org.eclipse.lsp.cobol.core.model.tree.Node;
 import org.eclipse.lsp.cobol.core.preprocessor.TextPreprocessor;
 import org.eclipse.lsp.cobol.core.preprocessor.delegates.util.LocalityMappingUtils;
 import org.eclipse.lsp.cobol.core.semantics.SemanticContext;
@@ -125,8 +126,9 @@ public class CobolLanguageEngine implements ThreadInterruptAspect {
             positionMapping,
             messageService,
             subroutineService);
-    visitor.visit(tree);
-
+    Node rootNode = visitor.visit(tree).get(0);
+    SyntaxTreeEngine syntaxTreeEngine = new SyntaxTreeEngine(rootNode, positionMapping, messageService);
+    accumulatedErrors.addAll(syntaxTreeEngine.processTree());
     SemanticContext context = visitor.finishAnalysis().unwrap(accumulatedErrors::addAll);
     accumulatedErrors.addAll(finalizeErrors(listener.getErrors(), positionMapping));
     accumulatedErrors.addAll(

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/engine/SyntaxTreeEngine.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/engine/SyntaxTreeEngine.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.engine;
+
+import org.antlr.v4.runtime.Token;
+import org.eclipse.lsp.cobol.core.messages.MessageService;
+import org.eclipse.lsp.cobol.core.model.Locality;
+import org.eclipse.lsp.cobol.core.model.SyntaxError;
+import org.eclipse.lsp.cobol.core.model.tree.*;
+import org.eclipse.lsp.cobol.core.model.variables.Variable;
+import org.eclipse.lsp.cobol.core.visitor.VariableDefinitionDelegate;
+import org.eclipse.lsp.cobol.core.visitor.VariableUsageDelegate;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This class is responsible for processing the syntax tree.
+ */
+public class SyntaxTreeEngine {
+  private final Node rootNode;
+  private final Map<Token, Locality> positionMapping;
+  private final MessageService messageService;
+
+  public SyntaxTreeEngine(Node rootNode, Map<Token, Locality> positionMapping, MessageService messageService) {
+    this.rootNode = rootNode;
+    this.positionMapping = positionMapping;
+    this.messageService = messageService;
+  }
+
+  /**
+   * Run the process under the syntax tree.
+   *
+   * @return the list of syntax errors.
+   */
+  public List<SyntaxError> processTree() {
+    return rootNode.getDepthFirstStream()
+        .filter(it -> it.getNodeType() == NodeType.PROGRAM)
+        .map(it -> processProgram((ProgramNode) it))
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+  }
+
+  private List<SyntaxError> processProgram(ProgramNode programNode) {
+    VariableDefinitionDelegate variablesDelegate = new VariableDefinitionDelegate(positionMapping, messageService);
+    VariableUsageDelegate variableUsageDelegate = new VariableUsageDelegate(positionMapping, messageService);
+    programNode.getDepthFirstStream()
+        .forEach(node -> {
+          if (node.getNodeType() == NodeType.SECTION) {
+            variablesDelegate.notifySectionChanged();
+          }
+          if (node.getNodeType() == NodeType.ANTLR_VARIABLE_DEFINITION) {
+            AntlrVariableDefinitionNode definitionNode = (AntlrVariableDefinitionNode) node;
+            Optional.ofNullable(definitionNode.getFormat1Context()).ifPresent(variablesDelegate::defineVariable);
+            Optional.ofNullable(definitionNode.getFormat1Level77Context()).ifPresent(variablesDelegate::defineVariable);
+            Optional.ofNullable(definitionNode.getFormat2Context()).ifPresent(variablesDelegate::defineVariable);
+            Optional.ofNullable(definitionNode.getFormat3Context()).ifPresent(variablesDelegate::defineVariable);
+            Optional.ofNullable(definitionNode.getSwitchNameClauseContext()).ifPresent(variablesDelegate::defineVariable);
+          }
+        });
+    programNode.getDepthFirstStream()
+        .filter(it -> it.getNodeType() == NodeType.VARIABLE_USAGE)
+        .forEach(node -> {
+          VariableUsageNode variableUsage = (VariableUsageNode) node;
+          switch (variableUsage.getVariableUsageType()) {
+            case DATA_NAME:
+              variableUsageDelegate.handleDataName(variableUsage.getDataName(), variableUsage.getLocality(),
+                  variableUsage.getDataNameFormat1Context());
+              break;
+            case TABLE_CALL:
+              variableUsageDelegate.handleTableCall(variableUsage.getDataName(), variableUsage.getLocality());
+              break;
+            case CONDITION_CALL:
+              variableUsageDelegate.handleConditionCall(variableUsage.getDataName(), variableUsage.getLocality(),
+                  variableUsage.getNameReferenceContext());
+              break;
+            default:
+              // No other variable usage types exist, this is unreachable, but just in case.
+              break;
+          }
+        });
+    List<SyntaxError> errors = new ArrayList<>();
+    Collection<Variable> definedVariables = variablesDelegate.finishDefinitionAnalysis().unwrap(errors::addAll);
+    errors.addAll(variableUsageDelegate.updateUsageAndGenerateErrors(definedVariables));
+    return errors;
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/AntlrVariableDefinitionNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/AntlrVariableDefinitionNode.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.eclipse.lsp.cobol.core.CobolParser;
+import org.eclipse.lsp.cobol.core.visitor.VariableDefinitionDelegate;
+
+/**
+ * The class represents a variable definition.
+ * This store ANTLR context to be used in {@link VariableDefinitionDelegate}. This is a temporal solution and must be
+ * removed.
+ */
+@Value
+public class AntlrVariableDefinitionNode extends Node {
+  @NonFinal
+  CobolParser.DataDescriptionEntryFormat1Context format1Context;
+  @NonFinal
+  CobolParser.DataDescriptionEntryFormat1Level77Context format1Level77Context;
+  @NonFinal
+  CobolParser.DataDescriptionEntryFormat2Context format2Context;
+  @NonFinal
+  CobolParser.DataDescriptionEntryFormat3Context format3Context;
+  @NonFinal
+  CobolParser.EnvironmentSwitchNameClauseContext switchNameClauseContext;
+
+  public AntlrVariableDefinitionNode(CobolParser.DataDescriptionEntryFormat1Context format1Context) {
+    super(null, NodeType.ANTLR_VARIABLE_DEFINITION);
+    this.format1Context = format1Context;
+  }
+
+  public AntlrVariableDefinitionNode(CobolParser.DataDescriptionEntryFormat1Level77Context format1Level77Context) {
+    super(null, NodeType.ANTLR_VARIABLE_DEFINITION);
+    this.format1Level77Context = format1Level77Context;
+  }
+
+  public AntlrVariableDefinitionNode(CobolParser.DataDescriptionEntryFormat2Context format2Context) {
+    super(null, NodeType.ANTLR_VARIABLE_DEFINITION);
+    this.format2Context = format2Context;
+  }
+
+  public AntlrVariableDefinitionNode(CobolParser.DataDescriptionEntryFormat3Context format3Context) {
+    super(null, NodeType.ANTLR_VARIABLE_DEFINITION);
+    this.format3Context = format3Context;
+  }
+
+  public AntlrVariableDefinitionNode(CobolParser.EnvironmentSwitchNameClauseContext switchNameClauseContext) {
+    super(null, NodeType.ANTLR_VARIABLE_DEFINITION);
+    this.switchNameClauseContext = switchNameClauseContext;
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/Node.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/Node.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import org.eclipse.lsp4j.Location;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The class represents a Node in source structure tree.
+ */
+public abstract class Node {
+  private final Location location;
+  private Node parent;
+  private final List<Node> children = new ArrayList<>();
+  private final NodeType nodeType;
+
+  protected Node(Location location, NodeType nodeType) {
+    this.location = location;
+    this.nodeType = nodeType;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public Node getParent() {
+    return parent;
+  }
+
+  public List<Node> getChildren() {
+    return children;
+  }
+
+  /**
+   * Add a child node to this node and updates the child parent link.
+   *
+   * @param node a child node.
+   */
+  public void addChild(Node node) {
+    node.setParent(this);
+    children.add(node);
+  }
+
+  public NodeType getNodeType() {
+    return nodeType;
+  }
+
+  protected void setParent(Node parent) {
+    this.parent = parent;
+  }
+
+  /**
+   * Get a stream with all nested children starting with this instance.
+   *
+   * @return the stream with all underline children.
+   */
+  public Stream<Node> getDepthFirstStream() {
+    return Stream.concat(Stream.of(this), children.stream().flatMap(Node::getDepthFirstStream));
+  }
+
+  /**
+   * Get nearest parent with specified type starting with this.
+   * Exception: theNode == theNode.getNearestParentByType(theNode.getNodeType()).get();
+   *
+   * @param type required node type.
+   * @return an optional with requested nearest node.
+   */
+  public Optional<Node> getNearestParentByType(NodeType type) {
+    if (nodeType == type) return Optional.of(this);
+    return Optional.ofNullable(parent).flatMap(it -> it.getNearestParentByType(type));
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/NodeType.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/NodeType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+/**
+ * Enumeration of Node types.
+ */
+public enum NodeType {
+  ROOT,
+  PROGRAM,
+  SECTION,
+  VARIABLE_DEFINITION,
+  VARIABLE_USAGE,
+  ANTLR_VARIABLE_DEFINITION,
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/ProgramNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/ProgramNode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import org.eclipse.lsp4j.Location;
+
+/**
+ * This class represents program context in COBOL.
+ */
+public class ProgramNode extends Node {
+  public ProgramNode(Location location) {
+    super(location, NodeType.PROGRAM);
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/RootNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/RootNode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import org.eclipse.lsp4j.Location;
+
+/**
+ * The class represents the root. All trees must start with one root node.
+ */
+public class RootNode extends Node {
+  public RootNode(Location location) {
+    super(location, NodeType.ROOT);
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/SectionNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/SectionNode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import org.eclipse.lsp4j.Location;
+
+/**
+ * The class represents section context in COBOL.
+ */
+public class SectionNode extends Node {
+  public SectionNode(Location location) {
+    super(location, NodeType.SECTION);
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/VariableDefinitionNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/VariableDefinitionNode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import org.eclipse.lsp4j.Location;
+
+/**
+ * The node represents a variable definition. This is a stub and must be rewritten.
+ */
+public class VariableDefinitionNode extends Node {
+  public VariableDefinitionNode(Location location) {
+    super(location, NodeType.VARIABLE_DEFINITION);
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/VariableUsageNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/VariableUsageNode.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.eclipse.lsp.cobol.core.CobolParser;
+import org.eclipse.lsp.cobol.core.model.Locality;
+
+/**
+ * The class represents variable usage in COBOL program.
+ * This must be extended with a link to variable definition.
+ */
+@Value
+public class VariableUsageNode extends Node {
+  String dataName;
+  Locality locality;
+  Type variableUsageType;
+  @NonFinal
+  CobolParser.QualifiedDataNameFormat1Context dataNameFormat1Context;
+  @NonFinal
+  CobolParser.ConditionNameReferenceContext nameReferenceContext;
+
+  public VariableUsageNode(String dataName,
+                           Locality locality,
+                           CobolParser.QualifiedDataNameFormat1Context dataNameFormat1Context) {
+    super(locality.toLocation(), NodeType.VARIABLE_USAGE);
+    this.dataName = dataName;
+    this.locality = locality;
+    this.dataNameFormat1Context = dataNameFormat1Context;
+    variableUsageType = Type.DATA_NAME;
+  }
+
+  public VariableUsageNode(String dataName, Locality locality) {
+    super(locality.toLocation(), NodeType.VARIABLE_USAGE);
+    this.dataName = dataName;
+    this.locality = locality;
+    variableUsageType = Type.TABLE_CALL;
+  }
+
+  public VariableUsageNode(String dataName,
+                           Locality locality,
+                           CobolParser.ConditionNameReferenceContext nameReferenceContext) {
+    super(locality.toLocation(), NodeType.VARIABLE_USAGE);
+    this.dataName = dataName;
+    this.locality = locality;
+    this.nameReferenceContext = nameReferenceContext;
+    variableUsageType = Type.CONDITION_CALL;
+  }
+
+  /**
+   * Represents different types of variable usages.
+   */
+  public enum Type {
+    DATA_NAME,
+    TABLE_CALL,
+    CONDITION_CALL,
+  }
+}

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableDefinitionDelegate.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableDefinitionDelegate.java
@@ -86,7 +86,7 @@ public class VariableDefinitionDelegate {
    *
    * @param ctx - a {@link DataDescriptionEntryFormat1Context} to retrieve the variable
    */
-  void defineVariable(@NonNull DataDescriptionEntryFormat1Context ctx) {
+  public void defineVariable(@NonNull DataDescriptionEntryFormat1Context ctx) {
     // TODO: add support for the REDEFINES clause:
     // TODO: 1. redefined variable defined
     // TODO: 2. add variable usage for REDEFINES
@@ -142,7 +142,7 @@ public class VariableDefinitionDelegate {
    *
    * @param ctx - a {@link DataDescriptionEntryFormat1Level77Context} to retrieve the variable
    */
-  void defineVariable(@NonNull DataDescriptionEntryFormat1Level77Context ctx) {
+  public void defineVariable(@NonNull DataDescriptionEntryFormat1Level77Context ctx) {
     VariableDefinitionContext variableDefinitionContext =
         VariableDefinitionContext.builder()
             .number(LEVEL_77)
@@ -175,7 +175,7 @@ public class VariableDefinitionDelegate {
    *
    * @param ctx - a {@link DataDescriptionEntryFormat2Context} to retrieve the variable
    */
-  void defineVariable(@NonNull DataDescriptionEntryFormat2Context ctx) {
+  public void defineVariable(@NonNull DataDescriptionEntryFormat2Context ctx) {
     VariableDefinitionContext variableDefinitionContext =
         VariableDefinitionContext.builder()
             .number(LEVEL_66)
@@ -200,7 +200,7 @@ public class VariableDefinitionDelegate {
    *
    * @param ctx - a {@link DataDescriptionEntryFormat3Context} to retrieve the variable
    */
-  void defineVariable(@NonNull DataDescriptionEntryFormat3Context ctx) {
+  public void defineVariable(@NonNull DataDescriptionEntryFormat3Context ctx) {
     VariableDefinitionContext variableDefinitionContext =
         VariableDefinitionContext.builder()
             .number(LEVEL_88)
@@ -226,7 +226,7 @@ public class VariableDefinitionDelegate {
    *
    * @param ctx - a {@link EnvironmentSwitchNameClauseContext} to retrieve the variable
    */
-  void defineVariable(EnvironmentSwitchNameClauseContext ctx) {
+  public void defineVariable(EnvironmentSwitchNameClauseContext ctx) {
     String name = retrieveName(ctx.mnemonicName());
     String systemName = ctx.environmentName().getText();
     variables.push(
@@ -241,7 +241,7 @@ public class VariableDefinitionDelegate {
    * Notify the variable delegate that the processing moved to another section in order to track the
    * structure correctness
    */
-  void notifySectionChanged() {
+  public void notifySectionChanged() {
     closePreviousStructure();
   }
 
@@ -251,7 +251,7 @@ public class VariableDefinitionDelegate {
    * @return the defined variables and found errors
    */
   @NonNull
-  ResultWithErrors<Collection<Variable>> finishDefinitionAnalysis() {
+  public ResultWithErrors<Collection<Variable>> finishDefinitionAnalysis() {
     closePreviousStructure();
     return new ResultWithErrors<>(new ArrayList<>(variables), new ArrayList<>(errors));
   }

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableUsageDelegate.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableUsageDelegate.java
@@ -40,7 +40,7 @@ import static java.util.stream.Collectors.toMap;
  */
 @Slf4j
 @RequiredArgsConstructor
-class VariableUsageDelegate {
+public class VariableUsageDelegate {
   private final List<VariableUsage> variableUsages = new ArrayList<>();
   private final Map<Token, Locality> positionMapping;
   private final MessageService messageService;
@@ -52,7 +52,7 @@ class VariableUsageDelegate {
    * @param locality the variable text position
    * @param ctx the ANTLR variable context
    */
-  void handleDataName(String dataName, Locality locality, QualifiedDataNameFormat1Context ctx) {
+  public void handleDataName(String dataName, Locality locality, QualifiedDataNameFormat1Context ctx) {
     List<QualifiedInDataContext> hierarchy = ctx.qualifiedInData();
     List<String> parents = createPatentsList(hierarchy.stream().map(this::getDataName2Context).collect(toList()));
     Map<String, Token> parentVariables = collectParentVariablesFromDataAndTable(hierarchy);
@@ -66,7 +66,7 @@ class VariableUsageDelegate {
    * @param locality the variable text position
    * @param ctx the ANTLR variable context
    */
-  void handleConditionCall(String dataName, Locality locality, ConditionNameReferenceContext ctx) {
+  public void handleConditionCall(String dataName, Locality locality, ConditionNameReferenceContext ctx) {
     List<DataName2Context> hierarchy = ctx.inData().stream().map(InDataContext::dataName2).collect(toList());
     List<String> parents = createPatentsList(hierarchy);
     Map<String, Token> parentVariables = collectParentVariablesFromInData(hierarchy);
@@ -79,7 +79,7 @@ class VariableUsageDelegate {
    * @param dataName the variable name
    * @param locality the variable text position
    */
-  void handleTableCall(String dataName, Locality locality) {
+  public void handleTableCall(String dataName, Locality locality) {
     variableUsages.add(new VariableUsage(dataName, Collections.emptyList(), locality, Collections.emptyMap()));
   }
 
@@ -89,7 +89,7 @@ class VariableUsageDelegate {
    * @param definedVariables the collection of COBOL variables
    * @return the list of usage errors
    */
-  List<SyntaxError> updateUsageAndGenerateErrors(Collection<Variable> definedVariables) {
+  public List<SyntaxError> updateUsageAndGenerateErrors(Collection<Variable> definedVariables) {
     Map<String, List<Variable>> convertedVariables = VariableUsageUtils.convertDefinedVariables(definedVariables);
     List<SyntaxError> errors = new ArrayList<>();
     for (VariableUsage variableUsage : variableUsages) {

--- a/server/src/test/java/org/eclipse/lsp/cobol/core/model/tree/NodeTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/core/model/tree/NodeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.lsp4j.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test {@link Node}
+ */
+class NodeTest {
+  private static final Location LOCATION = new Location();
+
+  @Test
+  void getDepthFirstStream() {
+    Node rootNode = new RootNode(LOCATION);
+    Node firstProg = new ProgramNode(LOCATION);
+    Node sectionNode = new SectionNode(LOCATION);
+    Node definition = new VariableDefinitionNode(LOCATION);
+    Node nestedProg = new ProgramNode(LOCATION);
+    Node secondProg = new ProgramNode(LOCATION);
+    Node anotherDefinition = new VariableDefinitionNode(LOCATION);
+
+    rootNode.addChild(firstProg);
+    firstProg.addChild(sectionNode);
+    sectionNode.addChild(definition);
+    firstProg.addChild(nestedProg);
+    rootNode.addChild(secondProg);
+    secondProg.addChild(anotherDefinition);
+
+    List<Node> expectedResult = ImmutableList.of(
+        rootNode, firstProg, sectionNode, definition, nestedProg, secondProg, anotherDefinition
+    );
+    assertEquals(expectedResult, rootNode.getDepthFirstStream().collect(Collectors.toList()));
+  }
+
+  @Test
+  void getParentByType() {
+    Node rootNode = new RootNode(LOCATION);
+    Node program = new ProgramNode(LOCATION);
+    rootNode.addChild(program);
+    Node nestedProgram = new ProgramNode(LOCATION);
+    program.addChild(nestedProgram);
+    Node section = new SectionNode(LOCATION);
+    nestedProgram.addChild(section);
+    Node definition = new VariableDefinitionNode(LOCATION);
+    section.addChild(definition);
+
+    assertFalse(rootNode.getNearestParentByType(NodeType.PROGRAM).isPresent());
+
+    Optional<Node> progFromDefinition = definition.getNearestParentByType(NodeType.PROGRAM);
+    assertTrue(progFromDefinition.isPresent());
+    assertEquals(nestedProgram, progFromDefinition.get());
+
+    Optional<Node> rootFromSection = section.getNearestParentByType(NodeType.ROOT);
+    assertTrue(rootFromSection.isPresent());
+    assertEquals(rootNode, rootFromSection.get());
+  }
+}

--- a/server/src/test/java/org/eclipse/lsp/cobol/core/visitor/VisitorSemanticAnalysisTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/core/visitor/VisitorSemanticAnalysisTest.java
@@ -46,39 +46,6 @@ class VisitorSemanticAnalysisTest {
   private static final String INVALID_VARIABLE = "invalid";
 
   /**
-   * Check if there is an error shown the processing token if a variable do not present in the
-   * semantic context.
-   */
-  @Test
-  void testVariableDefinitionNotFound() {
-    CustomToken token = createNewToken(INVALID_VARIABLE);
-    MessageService mockMessageService = mock(MessageService.class);
-    when(mockMessageService.getMessage(
-            matches("CobolVisitor.invalidDefMsg"), matches(INVALID_VARIABLE.toUpperCase())))
-        .thenReturn("Invalid definition for: INVALID");
-    CobolVisitor visitor =
-        new CobolVisitor(
-            "",
-            new NamedSubContext(),
-            mock(CommonTokenStream.class),
-            ImmutableMap.of(
-                token,
-                Locality.builder()
-                    .range(new Range(new Position(0, 0), new Position(0, 0)))
-                    .token(WRONG_TOKEN)
-                    .build()),
-            mockMessageService,
-            mock(SubroutineService.class));
-
-    visitor.visitQualifiedDataNameFormat1(mockMethod(token));
-
-    List<SyntaxError> errors = visitor.finishAnalysis().getErrors();
-    assertEquals(1, errors.size());
-    assertEquals(
-        "Invalid definition for: " + INVALID_VARIABLE.toUpperCase(), errors.get(0).getSuggestion());
-  }
-
-  /**
    * Check if visitor calculates distance between a wrong token and a keyword and returns a
    * suggestion with the closest keyword.
    */

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestProgramContexts.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestProgramContexts.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.service.delegates.validations.SourceInfoLevels;
+import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test checks that the second program in one file can use the same name for
+ * variable declaration as the first program.
+ */
+public class TestProgramContexts {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. FIRST.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*VARNAME}  PIC X(2).\n"
+          + "       Procedure Division.\n"
+          + "           move 1 to VARNAME.\n"
+          + "       End program FIRST.\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. SECOND.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*VARNAME}  PIC X(20).\n"
+          + "       01 {$*VARNAME}  PIC X(2).\n"
+          + "       Procedure Division.\n"
+          + "           move 1 to {VARNAME|1}.\n"
+          + "       End program SECOND.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(
+        "1",
+        new Diagnostic(
+            new Range(new Position(15, 21), new Position(15, 28)),
+            "Invalid definition for: VARNAME",
+            DiagnosticSeverity.Error,
+            SourceInfoLevels.ERROR.getText())));
+  }
+}


### PR DESCRIPTION
Each program context will be treated separately for variables error only.
Variable definitions, usages, etc works as before like in one context.