### PR TITLE
fix: fix coloring for string literal in continuation line

### DIFF
--- a/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
+++ b/clients/cobol-lsp-vscode-extension/syntaxes/COBOL.tmLanguage.json
@@ -39,7 +39,7 @@
     },
     "string-quoted-constant" : {
       "begin" : "'",
-      "end" : "'",
+      "end" : "'|$",
       "name" : "string.quoted.single.cobol"
     },
     "string-double-quoted-constant" : {


### PR DESCRIPTION
String literal can ends with ', " or the end of the line.
