### PR TITLE
fix: fix REDEFINES clause for the same group

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableDefinitionDelegate.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableDefinitionDelegate.java
@@ -277,7 +277,7 @@ public class VariableDefinitionDelegate {
       return;
     }
 
-    boolean notFound = true;
+    Variable originalVariable = null;
     Iterator<Variable> iterator = variables.iterator();
     if (iterator.hasNext()) {
       while (iterator.hasNext()) {
@@ -287,7 +287,7 @@ public class VariableDefinitionDelegate {
             addError(messages.getMessage("semantics.levelsMustMatch", redefinesName), positions.get(context.getParent().getStart()));
           }
           variable.addUsage(locality);
-          notFound = false;
+          originalVariable = variable;
           break;
         } else {
           if (levelNumber == variable.getLevelNumber()
@@ -296,8 +296,17 @@ public class VariableDefinitionDelegate {
           }
         }
       }
-      if (notFound) {
+      if (originalVariable == null) {
         addError(messages.getMessage("semantics.redefineImmediatelyFollow", redefinesName), locality);
+      } else {
+        StructuredVariable structuredVariable = structureStack.peek();
+        if (structuredVariable != null && !originalVariable.equals(structuredVariable)) {
+          String originalName = originalVariable.getName();
+          if (structuredVariable.getChildren().stream()
+              .noneMatch(v -> v.getName().equals(originalName))) {
+            addError(messages.getMessage("semantics.redefineSameGroup", redefinesName), locality);
+          }
+        }
       }
     }
   }

--- a/server/src/main/resources/resourceBundles/messages_en.properties
+++ b/server/src/main/resources/resourceBundles/messages_en.properties
@@ -13,6 +13,7 @@ CobolVisitor.progIDIssueMsg=There is an issue with PROGRAM-ID paragraph
 CobolVisitor.subroutineNotFound=%s: Subroutine not found
 semantics.redefinedContainValue=The redefining item cannot contain a VALUE clause: %s
 semantics.redefineImmediatelyFollow=REDEFINES line must immediately follow redefined item: %s
+semantics.redefineSameGroup=The redefining and redefined items must belong to the same group: %s
 semantics.levelsMustMatch=The redefining and redefined items must have the same level: %s
 Communications.noSyntaxError=No syntax errors detected in %s
 Communications.syntaxAnalysisInProgress=%s : Syntax analysis in progress

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestVariableRedefineSameGroup.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestVariableRedefineSameGroup.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.lsp.cobol.service.delegates.validations.SourceInfoLevels.ERROR;
+
+/**
+ * This test checks that redefined variable has the same group
+ */
+public class TestVariableRedefineSameGroup {
+  private static final String REDEFINES_SAME_GROUP =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.      EMPPROJ.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       DATA DIVISION. \n"
+          + "         WORKING-STORAGE SECTION.\n"
+          + "          01 {$*WS-DESCRIPTION1}.\n"
+          + "              05 {$*WS-DATE1} PIC X(20).\n"
+          + "          01 {$*WS-DESCRIPTION2}.\n"
+          + "               05 {$*WS-DATE2} REDEFINES {$WS-DATE1|1} PIC 9(8).";
+
+  @Test
+  void testError() {
+    UseCaseEngine.runTest(
+        REDEFINES_SAME_GROUP,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                null,
+                "The redefining and redefined items must belong to the same group: WS-DATE1",
+                DiagnosticSeverity.Error,
+                ERROR.getText())));
+  }
+}


### PR DESCRIPTION
The redefining and redefined items must belong to the same group.

Signed-off-by: Leonid Baranov <leonid.baranov@broadcom.com>