### PR TITLE
refactor: add timers inside CobolLanguageEngine

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/engine/Timing.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/engine/Timing.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.engine;
+
+import lombok.Value;
+
+/**
+ * The collection of timing data.
+ */
+@Value
+class Timing {
+  long preprocessorTime;
+  long parserTime;
+  long mappingTime;
+  long visitorTime;
+  long syntaxTreeTime;
+  long lateErrorProcessingTime;
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * The collection of timers.
+   */
+  @Value
+  static class Builder {
+    Timer preprocessorTimer = new Timer();
+    Timer parserTimer = new Timer();
+    Timer mappingTimer = new Timer();
+    Timer visitorTimer = new Timer();
+    Timer syntaxTreeTimer = new Timer();
+    Timer lateErrorProcessingTimer = new Timer();
+
+    Timing build() {
+      return new Timing(
+          preprocessorTimer.getTotalTime(),
+          parserTimer.getTotalTime(),
+          mappingTimer.getTotalTime(),
+          visitorTimer.getTotalTime(),
+          syntaxTreeTimer.getTotalTime(),
+          lateErrorProcessingTimer.getTotalTime()
+      );
+    }
+  }
+
+  /**
+   * The stop watch timer.
+   */
+  static class Timer {
+    long startTime = 0;
+    long totalTime = 0;
+
+    void start() {
+      if (startTime != 0)
+        throw new RuntimeException("The timer must starts only once");
+      startTime = System.currentTimeMillis();
+    }
+
+    void stop() {
+      if (totalTime != 0)
+        throw new RuntimeException("The timer must stops only once");
+      totalTime = System.currentTimeMillis() - startTime;
+    }
+
+    long getTotalTime() {
+      return totalTime;
+    }
+  }
+}


### PR DESCRIPTION
Example log piece:
```
Preprocessor: 946, parser: 19256, mapping: 19, visitor: 349, syntaxTree: 87, late error processing: 0
```