### PR TITLE
refactor: Unify dataName parser rule

### DIFF
--- a/server/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
+++ b/server/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CICSParser.g4
@@ -1030,7 +1030,7 @@ generalIdentifier
    ;
 
 tableCall
-   : dataName2 (LPARENCHAR subscript (COMMACHAR? subscript)* RPARENCHAR)* referenceModifier?
+   : dataName (LPARENCHAR subscript (COMMACHAR? subscript)* RPARENCHAR)* referenceModifier?
    ;
 
 functionCall
@@ -1097,7 +1097,7 @@ specialRegister
 // in ----------------------------------
 
 inData
-   : (IN | OF) dataName2
+   : (IN | OF) dataName
    ;
 
 inFile
@@ -1147,14 +1147,6 @@ conditionName
    ;
 
 dataName
-   : cobolWord
-   ;
-
-dataName1
-   : cobolWord
-   ;
-
-dataName2
    : cobolWord
    ;
 

--- a/server/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -714,7 +714,7 @@ dataDescriptionEntryFormat3
    ;
 
 entryName
-   : (FILLER | dataName1)
+   : (FILLER | dataName)
    ;
 
 dataGroupUsageClause
@@ -841,7 +841,7 @@ usageFormat
    ;
 
 dataUsingClause
-   : USING (LANGUAGE | CONVENTION) OF? (cobolWord | dataName)
+   : USING (LANGUAGE | CONVENTION) OF? dataName
    ;
 
 dataValueClause

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
@@ -565,9 +565,9 @@ public class CobolVisitor extends CobolParserBaseVisitor<List<Node>> {
   @Override
   public List<Node> visitTableCall(TableCallContext ctx) {
     String dataName =
-        ofNullable(ctx.dataName2()).map(RuleContext::getText).map(String::toUpperCase).orElse("");
+        ofNullable(ctx.dataName()).map(RuleContext::getText).map(String::toUpperCase).orElse("");
     List<Node> result = new ArrayList<>();
-    getLocality(ctx.dataName2().getStart())
+    getLocality(ctx.dataName().getStart())
         .ifPresent(
             locality -> {
               if (constants.contains(dataName)) constants.addUsage(dataName, locality.toLocation());

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableUsageDelegate.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VariableUsageDelegate.java
@@ -64,7 +64,7 @@ public class VariableUsageDelegate {
    * @param ctx the ANTLR variable context
    */
   public void handleConditionCall(String dataName, Locality locality, ConditionNameReferenceContext ctx) {
-    List<DataName2Context> hierarchy = ctx.inData().stream().map(InDataContext::dataName2).collect(toList());
+    List<DataNameContext> hierarchy = ctx.inData().stream().map(InDataContext::dataName).collect(toList());
     List<String> parents = createPatentsList(hierarchy);
     Map<String, Token> parentVariables = collectParentVariablesFromInData(hierarchy);
     variableUsages.add(new VariableUsage(dataName, parents, locality, parentVariables));
@@ -105,7 +105,7 @@ public class VariableUsageDelegate {
     return new ResultWithErrors<>(variablesByUsages, errors);
   }
 
-  private List<String> createPatentsList(List<DataName2Context> hierarchy) {
+  private List<String> createPatentsList(List<DataNameContext> hierarchy) {
     return hierarchy.stream()
             .map(RuleContext::getText)
             .map(String::toUpperCase)
@@ -118,7 +118,7 @@ public class VariableUsageDelegate {
         hierarchy.stream()
             .map(QualifiedInDataContext::inData)
             .filter(Objects::nonNull)
-            .map(InDataContext::dataName2)
+            .map(InDataContext::dataName)
             .collect(toMap(it -> it.getText().toUpperCase(), ParserRuleContext::getStart));
 
     parentVariables.putAll(
@@ -130,7 +130,7 @@ public class VariableUsageDelegate {
     return parentVariables;
   }
 
-  private Map<String, Token> collectParentVariablesFromInData(List<DataName2Context> hierarchy) {
+  private Map<String, Token> collectParentVariablesFromInData(List<DataNameContext> hierarchy) {
     return hierarchy.stream()
         .collect(toMap(it -> it.getText().toUpperCase(), ParserRuleContext::getStart));
   }
@@ -145,14 +145,14 @@ public class VariableUsageDelegate {
     }
   }
 
-  private DataName2Context getDataName2Context(QualifiedInDataContext node) {
+  private DataNameContext getDataName2Context(QualifiedInDataContext node) {
     return ofNullable(node.inData())
-        .map(InDataContext::dataName2)
+        .map(InDataContext::dataName)
         .orElseGet(
             () ->
                 ofNullable(node.inTable())
                     .map(InTableContext::tableCall)
-                    .map(TableCallContext::dataName2)
+                    .map(TableCallContext::dataName)
                     .orElse(null));
   }
 

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/visitor/VisitorHelper.java
@@ -48,7 +48,7 @@ public class VisitorHelper {
    */
   public String getName(EntryNameContext context) {
     return ofNullable(context)
-            .map(EntryNameContext::dataName1)
+            .map(EntryNameContext::dataName)
             .map(RuleContext::getText)
             .orElse(FILLER_NAME);
   }


### PR DESCRIPTION
Instead of three dataNames we can use one.