### PR TITLE
test: add more wait time for encoding tests

### DIFF
--- a/tests/cypress/integration/LSP/copybook.spec.js
+++ b/tests/cypress/integration/LSP/copybook.spec.js
@@ -434,6 +434,7 @@ context('This is a Copybook spec', () => {
         .openFile('TEST.CBL')
         .getLineByNumber(21)
         .type(`           COPY ${copybook}.`)
+        .wait(500)
         .getCurrentLineErrors({ expectedLine: 21 })
         .eq(0)
         .getHoverErrorMessage()


### PR DESCRIPTION
Fixes #1107. 
Results:
```

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  LSP/copybook.spec.js                     00:43        3        3        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:43        3        3        -        -        -  

```
Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>