### PR TITLE
Disable COPY MAID statements without numbers 

### DIFF
--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopyMaidAllowsOnlyValidLevelNumbers.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopyMaidAllowsOnlyValidLevelNumbers.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.positive.CobolText;
+import org.eclipse.lsp.cobol.service.delegates.validations.SourceInfoLevels;
+import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.junit.jupiter.api.Test;
+
+/** Test that COPY MAID statement allows only 01-49 level numbers */
+class TestCopyMaidAllowsOnlyValidLevelNumbers {
+  private static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.    TEST.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       49 COPY MAID {~PMOREC}.\n"
+          + "       {50|1} COPY MAID {~PMOREC}.\n"
+          + "       Procedure Division.";
+
+  private static final String COPYBOOK_CONTENT =
+      "       01  {$*ABC}.\n" + "           05 {$*DEF}     PIC S9(4) COMP.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(new CobolText("PMOREC", COPYBOOK_CONTENT)),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                null,
+                "Syntax error on '50' expected {CBL, END, EXEC, FILE, ID, IDENTIFICATION, LINKAGE, "
+                    + "LOCAL-STORAGE, PROCEDURE, PROCESS, WORKING-STORAGE, MAP, SCHEMA, '01-49', '66', '77', '88'}",
+                DiagnosticSeverity.Error,
+                SourceInfoLevels.ERROR.getText())));
+  }
+}

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopyMaidIsNotResolvedInProcedureDivision.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestCopyMaidIsNotResolvedInProcedureDivision.java
@@ -20,22 +20,25 @@ import org.eclipse.lsp.cobol.positive.CobolText;
 import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
 import org.junit.jupiter.api.Test;
 
-/** This test checks that COPY MAID statement is parsed correctly */
-class TestCopyMaidStatement {
+/** Test that COPY MAID statement is not resolved if it is in the PROCEDURE DIVISION */
+class TestCopyMaidIsNotResolvedInProcedureDivision {
   private static final String TEXT =
-      "        IDENTIFICATION DIVISION.\n"
-          + "          PROGRAM-ID. PARTEST.\n"
-          + "          DATA DIVISION.\n"
-          + "          WORKING-STORAGE SECTION.\n"
-          + "          01 COPY MAID {~NAME}.\n"
-          + "          PROCEDURE DIVISION.\n"
-          + "              DISPLAY {$ABC}.";
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID.    TEST.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 COPY MAID {~PMOREC}.\n"
+          + "       Procedure Division.\n"
+          + "           COPY MAID {~PMOREC}.\n"
+          + "           DISPLAY {$DEF}.";
 
-  private static final String COPYBOOK = "         01 {$*ABC} PIC 9.";
+  private static final String COPYBOOK_CONTENT =
+      "       01  {$*ABC}.\n" + "           05 {$*DEF}     PIC S9(4) COMP.";
 
   @Test
   void test() {
     UseCaseEngine.runTest(
-        TEXT, ImmutableList.of(new CobolText("NAME", COPYBOOK)), ImmutableMap.of());
+        TEXT, ImmutableList.of(new CobolText("PMOREC", COPYBOOK_CONTENT)), ImmutableMap.of());
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestMultiTokenError.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestMultiTokenError.java
@@ -32,13 +32,15 @@ class TestMultiTokenError {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(
-        "1",
-        new Diagnostic(
-            null,
-            "Variable FOO is not defined",
-            DiagnosticSeverity.Error,
-            SourceInfoLevels.ERROR.getText())
-    ));
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                null,
+                "Variable FOO is not defined",
+                DiagnosticSeverity.Error,
+                SourceInfoLevels.ERROR.getText())));
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestParametrised.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestParametrised.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 /** UseCase test example with variants */
-public class TestParametrised {
+class TestParametrised {
   private static final String TEXT_START =
       "       IDENTIFICATION DIVISION.\n"
           + "       PROGRAM-ID.    TEST1.\n"
@@ -39,21 +39,22 @@ public class TestParametrised {
   private static final String END_2 = "       01  {$*VAR}     PIC S9(4){|eof}";
 
   private static Stream<String> textsGetter() {
-    return Stream.of(END_1, END_2)
-        .map(end -> TEXT_START + end);
+    return Stream.of(END_1, END_2).map(end -> TEXT_START + end);
   }
 
   @ParameterizedTest
   @MethodSource("textsGetter")
   @DisplayName("Parameterized - different ends")
   void test(String text) {
-    UseCaseEngine.runTest(text, ImmutableList.of(), ImmutableMap.of(
-        "eof",
-        new Diagnostic(
-            null,
-            "Unexpected end of file",
-            DiagnosticSeverity.Error,
-            SourceInfoLevels.ERROR.getText())
-    ));
+    UseCaseEngine.runTest(
+        text,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "eof",
+            new Diagnostic(
+                null,
+                "Unexpected end of file",
+                DiagnosticSeverity.Error,
+                SourceInfoLevels.ERROR.getText())));
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestReplacing.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestReplacing.java
@@ -21,7 +21,7 @@ import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
 import org.junit.jupiter.api.Test;
 
 /** UseCase test example with replacing */
-public class TestReplacing {
+class TestReplacing {
   private static final String TEXT =
       "       IDENTIFICATION DIVISION.\n"
           + "       PROGRAM-ID.    TEST.\n"
@@ -36,8 +36,7 @@ public class TestReplacing {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, ImmutableList.of(
-        new CobolText("THEBOOK", COPYBOOK_CONTENT)
-    ), ImmutableMap.of());
+    UseCaseEngine.runTest(
+        TEXT, ImmutableList.of(new CobolText("THEBOOK", COPYBOOK_CONTENT)), ImmutableMap.of());
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithCopybook.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithCopybook.java
@@ -21,7 +21,7 @@ import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
 import org.junit.jupiter.api.Test;
 
 /** UseCase test example with copybooks */
-public class TestWithCopybook {
+class TestWithCopybook {
   private static final String TEXT =
       "       IDENTIFICATION DIVISION.\n"
           + "       PROGRAM-ID.    TEST.\n"
@@ -36,8 +36,7 @@ public class TestWithCopybook {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, ImmutableList.of(
-        new CobolText("THEBOOK", COPYBOOK_CONTENT)
-    ), ImmutableMap.of());
+    UseCaseEngine.runTest(
+        TEXT, ImmutableList.of(new CobolText("THEBOOK", COPYBOOK_CONTENT)), ImmutableMap.of());
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithErrorCheck.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithErrorCheck.java
@@ -23,7 +23,7 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
 /** UseCase test example when you expecting errors */
-public class TestWithErrorCheck {
+class TestWithErrorCheck {
   private static final String TEXT =
       "       IDENTIFICATION DIVISION.\n"
           + "       PROGRAM-ID.    TEST1.\n"
@@ -34,13 +34,15 @@ public class TestWithErrorCheck {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(
-        "1",
-        new Diagnostic(
-            null,
-            "Unexpected end of file",
-            DiagnosticSeverity.Error,
-            SourceInfoLevels.ERROR.getText())
-    ));
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                null,
+                "Unexpected end of file",
+                DiagnosticSeverity.Error,
+                SourceInfoLevels.ERROR.getText())));
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithSubroutines.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/example/TestWithSubroutines.java
@@ -22,9 +22,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.Test;
 
-/**
- * UseCase test example with subroutines
- */
+/** UseCase test example with subroutines */
 class TestWithSubroutines {
   public static final String TEXT =
       "       Identification Division.\n"
@@ -36,14 +34,16 @@ class TestWithSubroutines {
 
   @Test
   void test() {
-    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of(
+    UseCaseEngine.runTest(
+        TEXT,
+        ImmutableList.of(),
+        ImmutableMap.of(
             "1",
             new Diagnostic(
                 null,
                 "SECOND: Subroutine not found",
                 DiagnosticSeverity.Information,
-                SourceInfoLevels.INFO.getText())
-        ),
+                SourceInfoLevels.INFO.getText())),
         ImmutableList.of("FIRST"));
   }
 }


### PR DESCRIPTION
Closes #1208
COPY MAID statements that do not have the level number specified should not be resolved. It will disable such statements in the PROCEDURE DIVISION.