### PR TITLE
Add .cobol as a supported copybook extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 COBOL Language Support enhances the COBOL programming experience on your IDE. The extension leverages the language server protocol to provide autocomplete, syntax highlighting and coloring, and diagnostic features for COBOL code and copybooks. The COBOL Language Support extension can also connect to a mainframe using the Zowe Explorer extension to automatically retrieve copybooks used in your programs and store them in your workspace. 
 
-COBOL Language Support recognizes files with the extensions `.cob` and `.cbl` as COBOL files.
+COBOL Language Support recognizes files with the extensions `.cob` and `.cbl` and `.cobol` as COBOL files and `.cpy` and `.copy` as COBOL copybooks.
 
 > How can we improve COBOL Language Support? [Let us know on our Git repository](https://github.com/eclipse/che-che4z-lsp-for-cobol/issues)
 
@@ -167,7 +167,7 @@ The semantic analysis feature takes into account `COPY REPLACING` statements whi
 
 #### Syntax Coloring
 
-Syntax coloring is automatically enabled for copybook files with the extension `.cpy`, as long as they are used in the main COBOL file. You can also select the **COBOL Copybook** language mode to enable syntax coloring for copybook files.
+Syntax coloring is automatically enabled for copybook files with the extension `.cpy` and `.copy`, as long as they are used in the main COBOL file. You can also select the **COBOL Copybook** language mode to enable syntax coloring for copybook files.
 
 #### Go To Definition and Find All References
 

--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -84,7 +84,8 @@
             {
                 "id": "COBOL Copybook",
                 "extensions": [
-                    ".cpy"
+                    ".cpy",
+                    ".copy"
                 ],
                 "configuration": "./syntaxes/lang-config.json"
             }


### PR DESCRIPTION
Let users know that `.cpy` is recognized as a COBOL copybook and `.cobol` as a cobol file.