### PR TITLE
downgrade to vscode 1.55

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -8,7 +8,7 @@
     "preview": false,
     "publisher": "BroadcomMFD",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.55.0"
     },
     "repository": {
         "type": "git",
@@ -424,7 +424,7 @@
     "devDependencies": {
         "@types/jest": "^26.0.0",
         "@types/node": "^12.6.2",
-        "@types/vscode": "^1.56.0",
+        "@types/vscode": "^1.55.0",
         "jest": "^27.0.0",
         "jest-sonar-reporter": "^2.0.0",
         "patch-package": "^6.4.7",


### PR DESCRIPTION
The extension seems to work fine when post-changing it (I've done that in the 1.0.0-vsix and so far did not get any strange error message).

Please check if you need the 1.56 version and consider a downgrade, when not.