### PR TITLE
fix: variable declaration hover converts hyphens to underscores

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/ElementaryItemNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/ElementaryItemNode.java
@@ -63,7 +63,7 @@ public class ElementaryItemNode extends ElementaryNode {
   protected String getVariableDisplayString() {
     StringBuilder stringBuilder = new StringBuilder(getFormattedSuffix());
     if (picClause != null) stringBuilder.append(" PIC ").append(picClause);
-    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat);
+    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat.toDisplayString());
     if (StringUtils.isNoneBlank(value)) stringBuilder.append(" VALUE ").append(value);
     return stringBuilder.append(".").toString();
   }

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/MultiTableDataNameNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/MultiTableDataNameNode.java
@@ -47,7 +47,7 @@ public class MultiTableDataNameNode extends VariableWithLevelNode implements Usa
   protected String getVariableDisplayString() {
     StringBuilder stringBuilder = new StringBuilder(getFormattedSuffix());
     stringBuilder.append(String.format(" OCCURS %1$d TIMES", occursTimes));
-    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat);
+    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat.toDisplayString());
     return stringBuilder.append(".").toString();
   }
 }

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/TableDataNameNode.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/TableDataNameNode.java
@@ -61,7 +61,7 @@ public class TableDataNameNode extends ElementaryNode {
     StringBuilder stringBuilder = new StringBuilder(getFormattedSuffix());
     stringBuilder.append(String.format(" OCCURS %1$d TIMES", occursTimes));
     if (picClause != null) stringBuilder.append(" PIC ").append(picClause);
-    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat);
+    if (usageFormat != UsageFormat.UNDEFINED) stringBuilder.append(" USAGE ").append(usageFormat.toDisplayString());
     if (StringUtils.isNoneBlank(value)) stringBuilder.append(" VALUE ").append(value);
     return stringBuilder.append(".").toString();
   }

--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/UsageFormat.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/variables/UsageFormat.java
@@ -57,7 +57,7 @@ public enum UsageFormat {
   static {
     MAP =
         Arrays.stream(values())
-            .collect(toMap(it -> it.toString().replace("_", "-"), Function.identity()));
+            .collect(toMap(it -> it.toDisplayString(), Function.identity()));
   }
 
   /**
@@ -68,5 +68,14 @@ public enum UsageFormat {
    */
   public static UsageFormat of(String text) {
     return MAP.getOrDefault(text.toUpperCase(), UNDEFINED);
+  }
+
+  /**
+   * Return correct display representation of the format.
+   *
+   * @return the name to display
+   */
+  public String toDisplayString() {
+    return toString().replace("_", "-");
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/service/delegates/hover/VariableHoverTest.java
@@ -42,7 +42,8 @@ class VariableHoverTest {
       + "           10 {$*LEAF-2} PIC 9.\n"
       + "           88 {$*COND-ITEM1} VALUE 0.\n"
       + "           88 {$*COND-ITEM2} VALUES 1 THRU 3\n"
-      + "                                4 THROUGH 5.";
+      + "                                4 THROUGH 5.\n"
+      + "       01 {$*ANOTHER} PIC X(6) USAGE UTF-8.";
 
   @Test
   void getHoverForNullDocument() {
@@ -83,6 +84,15 @@ class VariableHoverTest {
     MarkedString markedString = hover.getContents().getLeft().get(0).getRight();
     assertEquals("cobol", markedString.getLanguage());
     assertEquals(result, markedString.getValue());
+  }
+
+  @Test
+  void getHoverWithUsage() {
+    Hover hover = variableHover.getHover(getModel(FULL_TEXT), getPosition(13, 16));
+    assertNotNull(hover);
+    MarkedString markedString = hover.getContents().getLeft().get(0).getRight();
+    assertEquals("cobol", markedString.getLanguage());
+    assertEquals("01 ANOTHER PIC X(6) USAGE UTF-8.", markedString.getValue());
   }
 
   private CobolDocumentModel getModel(String text) {


### PR DESCRIPTION
Closes #1319

Signed-off-by: Anton Grigorev <anton.grigorev@broadcom.com>