### PR TITLE
fix: Allow level 77 variable to be used for setting fields.

### DIFF
--- a/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/statements/SetUpDownByStatement.java
+++ b/server/src/main/java/org/eclipse/lsp/cobol/core/model/tree/statements/SetUpDownByStatement.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp.cobol.core.model.tree.variables.QualifiedReferenceNode;
 import org.eclipse.lsp.cobol.core.model.tree.variables.VariableType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** This class implements the logic for SET UP/DOWN BY statement. */
@@ -76,8 +77,10 @@ public class SetUpDownByStatement extends StatementNode {
   }
 
   private boolean variableProducesError(QualifiedReferenceNode variable) {
-    return !variable.getVariableDefinitionNode()
-        .map(defNode -> defNode.getVariableType() == VariableType.ELEMENTARY_ITEM)
+    List<VariableType> allowedNodes = Arrays.asList(VariableType.ELEMENTARY_ITEM, VariableType.STAND_ALONE_DATA_ITEM);
+    return !variable
+        .getVariableDefinitionNode()
+        .map(defNode -> allowedNodes.contains(defNode.getVariableType()))
         .orElse(true); // to ignore not defined variables
   }
 }

--- a/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestSetIndexDoOutproduceErrorForSendingFieldLevel77.java
+++ b/server/src/test/java/org/eclipse/lsp/cobol/usecases/TestSetIndexDoOutproduceErrorForSendingFieldLevel77.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.usecases.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** This test checks that level 77 variable can be used for setting field. */
+public class TestSetIndexDoOutproduceErrorForSendingFieldLevel77 {
+  private static final String TEXT =
+      "000100 IDENTIFICATION DIVISION.                                         NC1404.2\n"
+          + "000200 PROGRAM-ID.                                                      NC1404.2\n"
+          + "000300     NC140A.                                                      NC1404.2\n"
+          + "003700 DATA DIVISION.                                                   NC1404.2\n"
+          + "004200 WORKING-STORAGE SECTION.                                         NC1404.2\n"
+          + "004300 01  {$*GRP-TABLE1}.                                                  NC1404.2\n"
+          + "004400     02  {$*ELEM1}  PIC S999    OCCURS 100 TIMES                      NC1404.2\n"
+          + "004500              INDEXED BY {$*INDEX1}.                                  NC1404.2\n"
+          + "006000 77  {$*CS-3}     PICTURE S999    COMPUTATIONAL   VALUE ZERO.         NC1404.2\n"
+          + "021200 PROCEDURE DIVISION.                                              NC1404.2\n"
+          + "048400 {#*SET-TEST-003-01}.                                                 NC1404.2\n"
+          + "048700     SET {$INDEX1} UP BY {$CS-3}.                                       NC1404.2";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
Signed-off-by: ap891843 <aman.prashant@broadcom.com>