### PR TITLE
fix: cobol constants in test

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/extensionTest.spec.ts
@@ -83,7 +83,7 @@ describe("Check plugin extension for cobol starts successfully.", () => {
         expect(createFileWithGivenPath).toHaveBeenCalledTimes(1);
 
         expect(vscode.languages.registerCodeActionsProvider)
-            .toBeCalledWith({ scheme: "file", language: "COBOL" }, expect.any(CopybooksCodeActionProvider));
+            .toBeCalledWith({ scheme: "file", language: "cobol" }, expect.any(CopybooksCodeActionProvider));
 
     });
 

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/services/LanguageClientServiceTest.spec.ts
@@ -40,8 +40,8 @@ const copyBooksDownloader: CopybookDownloadService = new CopybookDownloadService
 const middleware: Middleware = new Middleware(copyBooksDownloader);
 let languageClientService: LanguageClientService;
 
-const SERVER_DESC = "LSP extension for COBOL language";
-const SERVER_ID = "COBOL";
+const SERVER_DESC = "LSP extension for cobol language";
+const SERVER_ID = "cobol";
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -103,13 +103,13 @@ describe("LanguageClientService positive scenario", () => {
         expect(languageClientService.start()).toBe(SERVER_STARTED_MSG);
         expect(LanguageClient).toHaveBeenLastCalledWith(SERVER_ID, SERVER_DESC,
             expect.any(Function), {
-            documentSelector: [SERVER_ID],
-            middleware: {
-                workspace: {
-                    configuration: expect.any(Function),
+                documentSelector: [SERVER_ID],
+                middleware: {
+                    workspace: {
+                        configuration: expect.any(Function),
+                    },
                 },
-            },
-        });
+            });
     });
 
     test("Test LanguageClientService fire a stop() command on LanguageClient", async () => {


### PR DESCRIPTION
AS IS:
Following tests are failing:

1. Test LanguageClientService starts language client
2. Check plugin extension for cobol starts

TO  BE:
SERVER_ID constant adjusted, with some indentation autoformatting
