### PR TITLE
fix: Allow timestamp as a column name.

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/Db2SqlParser.g4
@@ -1466,6 +1466,7 @@ dbs_collection_name: T=dbs_sql_identifier {validateLength($T.text, "collection n
 dbs_generic_name
     : ADDRESS | AVG | COUNT | COMMENT | FILENAME | GROUP | HOUR | HOURS | ID | IN | IDENTIFIER | LOCATION | LOCATOR
     | MAX | MIN | MONTH | NAME | NONNUMERICLITERAL | YEAR | DATE | DAY | SERVER | SQLCODE | TRANSACTION | TYPE | V1
+    | TIMESTAMP
     ;
 dbs_column_name: (dbs_generic_name DOT_FS)? T=dbs_generic_name {validateLength($T.text, "column name", 30);};
 dbs_constant : (dbs_string_constant | dbs_integer_constant | DATELITERAL);

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllDeclareStatements.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestSqlAllDeclareStatements.java
@@ -88,6 +88,7 @@ class TestSqlAllDeclareStatements {
           + "               BIRTHDATE DATE                ,\n"
           + "               SALARY    DECIMAL(9,2)        ,\n"
           + "               BONUS     DECIMAL(9,2)        ,\n"
+          + "               TIMESTAMP TIMESTAMP NOT NULL,\n"
           + "               COMM      DECIMAL(9,2)        );\n"
           + "             END-EXEC.";
 


### PR DESCRIPTION
Allow timestamp as a column name.

Signed-off-by: ap891843 <aman.prashant@broadcom.com>