### PR TITLE
Update local copybook setting description

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -153,7 +153,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Default list of relative local paths to search for copybooks",
+                    "description": "Default list of local paths to search for copybooks",
                     "uniqueItems": true
                 },
                 "cobol-lsp.cpy-manager.paths-dsn": {
@@ -177,7 +177,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Default list of relative local paths to search for MAID copybooks",
+                    "description": "Default list of local paths to search for MAID copybooks",
                     "uniqueItems": true
                 },
                 "cobol-lsp.cpy-manager.daco.paths-dsn": {
@@ -201,7 +201,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Default list of relative local paths to search for IDMS copybooks",
+                    "description": "Default list of local paths to search for IDMS copybooks",
                     "uniqueItems": true
                 },
                 "cobol-lsp.cpy-manager.idms.paths-dsn": {


### PR DESCRIPTION
Update local copybook settings description to remove the word "relative" - using relative paths is now just a recommendation, not a requirement. Solves #1511
Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>