### PR TITLE
feat: Update diagnostics when copybook are updated

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/domain/modules/ServiceModule.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/domain/modules/ServiceModule.java
@@ -19,6 +19,8 @@ import com.google.inject.multibindings.Multibinder;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.*;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepo;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepoImpl;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookServiceImpl;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActionProvider;
@@ -69,6 +71,7 @@ public class ServiceModule extends AbstractModule {
     bind(Occurrences.class).to(ElementOccurrences.class);
     bind(HoverProvider.class).to(VariableHover.class);
     bind(CFASTBuilder.class).to(CFASTBuilderImpl.class);
+    bind(CopybookReferenceRepo.class).to(CopybookReferenceRepoImpl.class);
 
     bindFormations();
     bindCompletions();

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolLanguageServer.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolLanguageServer.java
@@ -201,6 +201,12 @@ public class CobolLanguageServer implements LanguageServer {
         .fetchTextConfiguration(CPY_LOCAL_PATHS.label)
         .thenAccept(watchingService::addWatchers);
     settingsService
+            .fetchTextConfiguration(DaCo_CPY_LOCAL_PATHS.label)
+            .thenAccept(watchingService::addWatchers);
+    settingsService
+            .fetchTextConfiguration(IDMS_CPY_LOCAL_PATHS.label)
+            .thenAccept(watchingService::addWatchers);
+    settingsService
         .fetchTextConfiguration(SUBROUTINE_LOCAL_PATHS.label)
         .thenAccept(watchingService::addWatchers);
   }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
@@ -14,36 +14,18 @@
  */
 package org.eclipse.lsp.cobol.service;
 
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
-import static org.eclipse.lsp.cobol.core.model.tree.Node.hasType;
-import static org.eclipse.lsp.cobol.core.model.tree.NodeType.COPY;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.Subscribe;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.core.model.CopybookModel;
+import org.eclipse.lsp.cobol.core.model.CopybookName;
 import org.eclipse.lsp.cobol.core.model.extendedapi.ExtendedApiResult;
 import org.eclipse.lsp.cobol.core.model.tree.CopyNode;
 import org.eclipse.lsp.cobol.core.model.tree.Node;
@@ -54,6 +36,8 @@ import org.eclipse.lsp.cobol.domain.event.model.AnalysisResultEvent;
 import org.eclipse.lsp.cobol.jrpc.ExtendedApi;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookProcessingMode;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepo;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookService;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActions;
 import org.eclipse.lsp.cobol.service.delegates.communications.Communications;
 import org.eclipse.lsp.cobol.service.delegates.completions.Completions;
@@ -94,6 +78,31 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.net.URLDecoder.decode;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.lsp.cobol.core.model.tree.Node.hasType;
+import static org.eclipse.lsp.cobol.core.model.tree.NodeType.COPY;
+
 /**
  * This class is a set of end-points to apply text operations for COBOL documents. All the requests
  * that start with "textDocument" go here. The current implementation contains only supported
@@ -128,6 +137,8 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
   private final ConfigurationService configurationService;
   private DisposableLSPStateService disposableLSPStateService;
   private final CopybookNameService copybookNameService;
+  private final CopybookService copybookService;
+  private final CopybookReferenceRepo copybookReferenceRepo;
   private final Map<String, Map<String, List<Diagnostic>>> errorsByFileForEachProgram;
 
   @Inject
@@ -146,7 +157,9 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
       CFASTBuilder cfastBuilder,
       DisposableLSPStateService disposableLSPStateService,
       CopybookNameService copybookNameService,
-      ConfigurationService configurationService) {
+      ConfigurationService configurationService,
+      CopybookService copybookService,
+      CopybookReferenceRepo copybookReferenceRepo) {
     this.communications = communications;
     this.engine = engine;
     this.formations = formations;
@@ -161,6 +174,8 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
     this.configurationService = configurationService;
     this.copybookNameService = copybookNameService;
     this.errorsByFileForEachProgram = new HashMap<>();
+    this.copybookService = copybookService;
+    this.copybookReferenceRepo = copybookReferenceRepo;
     dataBus.subscribe(this);
   }
 
@@ -277,6 +292,7 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
     analyzeDocumentFirstTime(uri, text, false);
   }
 
+  @SneakyThrows
   @Override
   public void didChange(DidChangeTextDocumentParams params) {
     if (disposableLSPStateService.isServerShutdown()) return;
@@ -284,11 +300,30 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
     outlineMap.put(uri, new CompletableFuture<>());
     cfAstMap.put(uri, new CompletableFuture<>());
     if (copybookNameService.isCopybook(uri)) {
+      reanalyseOpenedPrograms(params, uri);
       return;
     }
     String text = params.getContentChanges().get(0).getText();
     interruptAnalysis(uri);
     analyzeChanges(uri, text);
+  }
+
+  private void reanalyseOpenedPrograms(DidChangeTextDocumentParams params, String uri)
+      throws UnsupportedEncodingException {
+    copybookReferenceRepo
+        .getCopybookUsageReference(decode(uri, StandardCharsets.UTF_8.name()))
+        .forEach(
+            val -> {
+              CopybookModel copybookModel =
+                  new CopybookModel(
+                      new CopybookName(
+                          val.getCopybookName().getDisplayName(),
+                          val.getCopybookName().getDialectType()),
+                      uri,
+                      params.getContentChanges().get(0).getText());
+              this.copybookService.store(copybookModel, val.getUri(), true);
+            });
+    dataBus.postData(new RunAnalysisEvent(false));
   }
 
   @Override

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepo.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.service.copybooks;
+
+import org.eclipse.lsp.cobol.core.model.CopybookModel;
+import org.eclipse.lsp.cobol.core.model.CopybookName;
+
+import java.util.Set;
+
+/** Provide API definition to search for COBOL programs that refers a copybooks file. */
+public interface CopybookReferenceRepo {
+  /**
+   * Gives all the usage references of a copybook URI.
+   *
+   * @param copybookUri is a URI of a copybook
+   * @return a set of all reference of passed copybook URI {@link CopybookModel}
+   */
+  Set<CopybookModel> getCopybookUsageReference(String copybookUri);
+
+  /** Clears all copybook references. */
+  void clearReferences();
+
+  /**
+   * Stores the references of cobol programs which refers a copybook.
+   *
+   * @param copybookName CopybookName for which references are to be maintained.
+   * @param documentUri Cobol program that refers the copybook
+   * @param copybookModel @copybookModel for the copybook.
+   */
+  void storeCopybookUsageReference(
+      CopybookName copybookName, String documentUri, CopybookModel copybookModel);
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImpl.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.service.copybooks;
+
+import org.eclipse.lsp.cobol.core.model.CopybookModel;
+import org.eclipse.lsp.cobol.core.model.CopybookName;
+
+import java.util.*;
+
+/**
+ * Provides API to search for COBOL programs that refers a copybooks file.
+ *
+ * <p>Implementation of @{@link CopybookReferenceRepo}.
+ */
+public class CopybookReferenceRepoImpl implements CopybookReferenceRepo {
+
+  private final Map<String, Set<CopybookModel>> copybookRef;
+
+  public CopybookReferenceRepoImpl() {
+    this.copybookRef = new HashMap<>();
+  }
+
+  /**
+   * Gives all the usage references of a copybook URI.
+   *
+   * @param copybookUri is a URI of a copybook
+   * @return a set of all reference of passed copybook URI {@link CopybookModel}
+   */
+  @Override
+  public Set<CopybookModel> getCopybookUsageReference(String copybookUri) {
+    return copybookRef.getOrDefault(copybookUri, Collections.emptySet());
+  }
+
+  /** Clears all copybook references. */
+  @Override
+  public void clearReferences() {
+    this.copybookRef.clear();
+  }
+
+  /**
+   * Stores the references of cobol programs which refers a copybook.
+   *
+   * @param copybookName CopybookName for which references are to be maintained.
+   * @param documentUri Cobol program that refers the copybook
+   * @param copybookModel @copybookModel for the copybook.
+   */
+  @Override
+  public void storeCopybookUsageReference(
+      CopybookName copybookName, String documentUri, CopybookModel copybookModel) {
+    Set<CopybookModel> copybookUsageRef =
+        copybookRef.computeIfAbsent(copybookModel.getUri(), k -> new HashSet<>());
+    CopybookModel copybookResolveContext =
+        new CopybookModel(copybookName, documentUri, copybookModel.getContent());
+    copybookUsageRef.add(copybookResolveContext);
+    copybookRef.put(copybookModel.getUri(), copybookUsageRef);
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookService.java
@@ -14,9 +14,8 @@
  */
 package org.eclipse.lsp.cobol.service.copybooks;
 
-import org.eclipse.lsp.cobol.core.model.CopybookModel;
-
 import lombok.NonNull;
+import org.eclipse.lsp.cobol.core.model.CopybookModel;
 import org.eclipse.lsp.cobol.core.model.CopybookName;
 
 /**
@@ -33,7 +32,8 @@ public interface CopybookService {
    * @param copybookName - the name of the copybook to be retrieved
    * @param programDocumentUri - the currently processing program document
    * @param documentUri - the currently processing document that contains the copy statement
-   * @param copybookConfig - contains config info like: copybook processing mode, target backend sql server
+   * @param copybookConfig - contains config info like: copybook processing mode, target backend sql
+   *     server
    * @param preprocess - indicates if copybook needs to be preprocessed after resolving
    * @return a CopybookModel that contains copybook name, its URI and the content
    */
@@ -51,4 +51,13 @@ public interface CopybookService {
    * @param documentUri is a URI of a document from where the copybook is imported.
    */
   void store(CopybookModel copybookModel, String documentUri);
+
+  /**
+   * Store the copybookModel in cache. Copybook depends on a document from where it is imported.
+   *
+   * @param copybookModel the copybook model
+   * @param documentUri is a URI of a document from where the copybook is imported.
+   * @param doCleanUp is copybook clean up required before storing copybookModel.
+   */
+  void store(CopybookModel copybookModel, String documentUri, boolean doCleanUp);
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/utils/SettingsParametersEnum.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/utils/SettingsParametersEnum.java
@@ -26,6 +26,8 @@ public enum SettingsParametersEnum {
   VERBOSE("verbose"),
   DATASETS("cpy-manager.paths-dsn"),
   CPY_LOCAL_PATHS("cpy-manager.paths-local"),
+  DaCo_CPY_LOCAL_PATHS("cpy-manager.daco.paths-local"),
+  IDMS_CPY_LOCAL_PATHS("cpy-manager.idms.paths-local"),
   CPY_EXTENSIONS("cpy-manager.copybook-extensions"),
   SUBROUTINE_LOCAL_PATHS("subroutine-manager.paths-local"),
   LSP_PREFIX("cobol-lsp"),

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/TestModule.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/TestModule.java
@@ -22,10 +22,7 @@ import org.eclipse.lsp.cobol.core.messages.MessageService;
 import org.eclipse.lsp.cobol.core.messages.PropertiesMessageService;
 import org.eclipse.lsp.cobol.jrpc.CobolLanguageClient;
 import org.eclipse.lsp.cobol.service.*;
-import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
-import org.eclipse.lsp.cobol.service.copybooks.CopybookNameServiceImpl;
-import org.eclipse.lsp.cobol.service.copybooks.CopybookService;
-import org.eclipse.lsp.cobol.service.copybooks.CopybookServiceImpl;
+import org.eclipse.lsp.cobol.service.copybooks.*;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActionProvider;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActions;
 import org.eclipse.lsp.cobol.service.delegates.actions.FindCopybookCommand;
@@ -74,6 +71,7 @@ public class TestModule extends AbstractModule {
     bind(WatcherService.class).to(WatcherServiceImpl.class);
     bind(FileSystemService.class).to(WorkspaceFileService.class);
     bind(CopybookNameService.class).to(CopybookNameServiceImpl.class);
+    bind(CopybookReferenceRepo.class).to(CopybookReferenceRepoImpl.class);
     bind(String.class)
         .annotatedWith(named(PATH_TO_TEST_RESOURCES))
         .toProvider(() -> ofNullable(getProperty(PATH_TO_TEST_RESOURCES)).orElse(""));

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/ClientServerIntegrationTest.java
@@ -22,6 +22,8 @@ import com.google.inject.Injector;
 import org.eclipse.lsp.cobol.ClientServerTestModule;
 import org.eclipse.lsp.cobol.ConfigurableTest;
 import org.eclipse.lsp.cobol.domain.modules.DatabusModule;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepo;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepoImpl;
 import org.eclipse.lsp.cobol.service.delegates.validations.LanguageEngineFacade;
 import org.eclipse.lsp.cobol.service.mocks.MockLanguageClient;
 import org.eclipse.lsp4j.*;
@@ -170,6 +172,7 @@ public class ClientServerIntegrationTest extends ConfigurableTest {
           protected void configure() {
             bind(LanguageEngineFacade.class).to(ClientServerIntegrationTestImpl.class);
             bind(TextDocumentService.class).to(CobolTextDocumentService.class);
+            bind(CopybookReferenceRepo.class).to(CopybookReferenceRepoImpl.class);
           }
         });
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolLanguageServerTest.java
@@ -23,11 +23,17 @@ import org.eclipse.lsp.cobol.core.model.ErrorCode;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
 import org.eclipse.lsp.cobol.service.delegates.completions.Keywords;
 import org.eclipse.lsp.cobol.service.utils.CustomThreadPoolExecutor;
-import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.verification.Times;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -81,6 +87,10 @@ class CobolLanguageServerTest {
     when(settingsService.fetchTextConfiguration(anyString())).thenCallRealMethod();
     when(settingsService.fetchConfiguration(CPY_LOCAL_PATHS.label))
         .thenReturn(completedFuture(singletonList(arr)));
+    when(settingsService.fetchConfiguration(DaCo_CPY_LOCAL_PATHS.label))
+            .thenReturn(completedFuture(singletonList(arr)));
+    when(settingsService.fetchConfiguration(IDMS_CPY_LOCAL_PATHS.label))
+            .thenReturn(completedFuture(singletonList(arr)));
     when(localeStore.notifyLocaleStore()).thenReturn(System.out::println);
     when(settingsService.fetchConfiguration(LOCALE.label))
         .thenReturn(completedFuture(singletonList(arr)));
@@ -106,8 +116,10 @@ class CobolLanguageServerTest {
     verify(watchingService).watchConfigurationChange();
     verify(watchingService).watchPredefinedFolder();
     verify(settingsService).fetchConfiguration(CPY_LOCAL_PATHS.label);
+    verify(settingsService).fetchConfiguration(DaCo_CPY_LOCAL_PATHS.label);
+    verify(settingsService).fetchConfiguration(IDMS_CPY_LOCAL_PATHS.label);
     verify(settingsService).fetchConfiguration(LOCALE.label);
-    verify(watchingService).addWatchers(singletonList(path));
+    verify(watchingService, new Times(3)).addWatchers(singletonList(path));
     verify(localeStore).notifyLocaleStore();
     verify(configurationService).updateConfigurationFromSettings();
   }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/CobolTextDocumentServiceTest.java
@@ -359,6 +359,19 @@ class CobolTextDocumentServiceTest extends MockTextDocumentService {
   }
 
   /**
+   * This test verifies that when a copybook document updated in DID_CHANGE mode, the analysis is triggered with updated cache
+   */
+  @Test
+  void copybookChangeTriggerReAnalysisDidChangeTest() {
+    mockSettingServiceForCopybooks(Boolean.TRUE);
+    service.didChange(
+            new DidChangeTextDocumentParams(
+                    new VersionedTextDocumentIdentifier(COPYBOOK_URI, 0),
+                    ImmutableList.of(new TextDocumentContentChangeEvent(INCORRECT_TEXT_EXAMPLE))));
+    verify(broker).postData(any(RunAnalysisEvent.class));
+  }
+
+  /**
    * This test checks that {@link CobolTextDocumentService} is subscribed to the databus events and
    * may re-run analysis of the open documents if it receives a notification.
    */

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImplTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookReferenceRepoImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.service.copybooks;
+
+import org.eclipse.lsp.cobol.core.model.CopybookModel;
+import org.eclipse.lsp.cobol.core.model.CopybookName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test @{@link CopybookReferenceRepo} */
+class CopybookReferenceRepoImplTest {
+
+  public static final String DOCUMENT_URI = "file:///c%3A/workspace/document.cbl";
+  private static final String CPY_URI = "file:///c%3A/workspace/.c4z/.copybooks/PARENT.CPY";
+  public static final String COPYBOOK_CONTENT = "sample copybook text";
+
+  @Test
+  void clearReferences() {
+    CopybookReferenceRepo repo = storeReferences();
+    assertEquals(1, setUpRepo().size());
+    repo.clearReferences();
+    assertEquals(0, repo.getCopybookUsageReference(CPY_URI).size());
+  }
+
+  @Test
+  void getCopybookUsageReference() {
+    Set<CopybookModel> copybookUsageReference = setUpRepo();
+    assertEquals(1, copybookUsageReference.size());
+    CopybookModel referencedCopybookModels = copybookUsageReference.toArray(new CopybookModel[0])[0];
+    assertEquals(referencedCopybookModels.getContent(), COPYBOOK_CONTENT);
+    assertEquals(referencedCopybookModels.getUri(), DOCUMENT_URI);
+  }
+
+  private Set<CopybookModel> setUpRepo() {
+    CopybookReferenceRepo repo = storeReferences();
+    return repo.getCopybookUsageReference(CPY_URI);
+  }
+
+  private CopybookReferenceRepo storeReferences() {
+    CopybookReferenceRepo repo = new CopybookReferenceRepoImpl();
+    CopybookName copybookName = new CopybookName("COPYBOOK");
+    CopybookModel copybookModel = new CopybookModel(copybookName, CPY_URI, COPYBOOK_CONTENT);
+    repo.storeCopybookUsageReference(copybookName, DOCUMENT_URI, copybookModel);
+    return repo;
+  }
+}

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/mocks/MockTextDocumentService.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/mocks/MockTextDocumentService.java
@@ -24,6 +24,9 @@ import org.eclipse.lsp.cobol.service.CobolLSPServerStateService;
 import org.eclipse.lsp.cobol.service.CobolTextDocumentService;
 import org.eclipse.lsp.cobol.service.ConfigurationService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookNameService;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepo;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepoImpl;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookService;
 import org.eclipse.lsp.cobol.service.delegates.actions.CodeActions;
 import org.eclipse.lsp.cobol.service.delegates.communications.Communications;
 import org.eclipse.lsp.cobol.service.delegates.completions.Completions;
@@ -51,7 +54,8 @@ public class MockTextDocumentService {
   @Mock protected HoverProvider hoverProvider;
   @Mock protected ConfigurationService configurationService;
   @Mock protected CopybookNameService copybookNameService;
-
+  @Mock protected CopybookService copybookService;
+  protected CopybookReferenceRepo copybookReferenceRepo = new CopybookReferenceRepoImpl();
 
   /**
    * Give a dummy {@link CobolTextDocumentService} with mocked attributes for testing. All tasks run
@@ -72,6 +76,8 @@ public class MockTextDocumentService {
         .disposableLSPStateService(new CobolLSPServerStateService())
         .hoverProvider(hoverProvider)
         .configurationService(configurationService)
+        .copybookService(copybookService)
+        .copybookReferenceRepo(new CopybookReferenceRepoImpl())
         .build();
   }
 
@@ -97,7 +103,6 @@ public class MockTextDocumentService {
   }
 
   protected void mockSettingServiceForCopybooks(boolean answer) {
-    when(copybookNameService.isCopybook(any()))
-        .thenReturn(answer);
+    when(copybookNameService.isCopybook(any())).thenReturn(answer);
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/engine/UseCaseUtils.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/engine/UseCaseUtils.java
@@ -40,6 +40,10 @@ import org.eclipse.lsp.cobol.positive.CobolText;
 import org.eclipse.lsp.cobol.service.SettingsService;
 import org.eclipse.lsp.cobol.service.SubroutineService;
 import org.eclipse.lsp.cobol.service.SubroutineServiceImpl;
+import org.eclipse.lsp.cobol.service.WatcherService;
+import org.eclipse.lsp.cobol.service.WatcherServiceImpl;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepo;
+import org.eclipse.lsp.cobol.service.copybooks.CopybookReferenceRepoImpl;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookService;
 import org.eclipse.lsp.cobol.service.copybooks.CopybookServiceImpl;
 import org.eclipse.lsp.cobol.service.delegates.validations.AnalysisResult;
@@ -133,6 +137,8 @@ public class UseCaseUtils {
                 bind(CobolLanguageClient.class).toInstance(languageClient);
                 bind(SubroutineService.class).to(SubroutineServiceImpl.class);
                 bind(TextPreprocessor.class).to(TextPreprocessorImpl.class);
+                bind(WatcherService.class).to(WatcherServiceImpl.class);
+                bind(CopybookReferenceRepo.class).toInstance(new CopybookReferenceRepoImpl());
               }
             });
 


### PR DESCRIPTION
Update diagnostics when copybook are updated.

1. any change in dialect (e.g. MAID) copybook will result in rescanning and updating	of error list in opened program.
2. works even without saving the changed copybook.

Signed-off-by: ap891843 <aman.prashant@broadcom.com>