### PR TITLE
build: Remove jenkins parameter for integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,9 +60,6 @@ boolean isTimeTriggeredBuild() {
 
 pipeline {
     agent none
-    parameters {
-        booleanParam(defaultValue: false, description: 'Run integration tests.', name: 'integrationTests')
-    }
     triggers {
         // Only development branch has nightly builds
         cron(env.BRANCH_NAME == 'development' ? '20 22 * * 1-5' : '')


### PR DESCRIPTION
Remove jenkins parameter for integration tests

Signed-off-by: ap891843 <aman.prashant@broadcom.com>