### PR TITLE
fix: Update copybook identification regex to support  all use cases

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContent.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContent.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 public class CopybookIdentificationServiceBasedOnContent implements CopybookIdentificationService {
   private final Pattern detectCobolProgram =
       Pattern.compile(
-          "(?i)^(?<sequence>.{0,6})(?<indicator>.?)(PROGRAM-ID)\\s*\\.\\s+(?<programName>.{1,30})\\s*\\.",
+          "(?i)^(?<sequence>.{0,6})(?<indicator>.?)\\s*(PROGRAM-ID)\\s*\\.\\s*(?<programName>.{1,30})\\s*\\.",
           Pattern.MULTILINE);
   /**
    * Identifies a copybook based on the content. If the text contains a valid program-id, we detect

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContentTest.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/service/copybooks/CopybookIdentificationServiceBasedOnContentTest.java
@@ -64,4 +64,18 @@ class CopybookIdentificationServiceBasedOnContentTest {
     doc.setText(content);
     Assertions.assertTrue(service.isCopybook(doc.getUri(), doc.getText(), ImmutableList.of()));
   }
+
+  @Test
+  void WhenNoSpaceBetweenProgmIDAndProgramName_thenReturnFalse() {
+    String content =
+        "      *RETRIEVAL                                                        00340200\n"
+            + "      *DMLIST                                                           00340301\n"
+            + "       IDENTIFICATION DIVISION.                                         00340401\n"
+            + "            PROGRAM-ID.EMPRPT. ";
+
+    CopybookIdentificationService service = new CopybookIdentificationServiceBasedOnContent();
+    TextDocumentItem doc = new TextDocumentItem();
+    doc.setText(content);
+    Assertions.assertFalse(service.isCopybook(doc.getUri(), doc.getText(), ImmutableList.of()));
+  }
 }


### PR DESCRIPTION
Update copybook identification regex to support all use cases

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>