### PR TITLE
Fix: support glob with more then * magic chars

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/glob.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/glob.ts
@@ -1,1 +1,2 @@
 export const sync = jest.fn(x => [x]);
+export const hasMagic = jest.fn(x => x.includes("*"));

--- a/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__mocks__/vscode.ts
@@ -17,7 +17,15 @@ import * as url from "url";
 // tslint:disable: no-namespace no-empty
 export namespace workspace {
     export const workspaceFolders: [] = [];
-    export function getConfiguration() { }
+    export function getConfiguration() {
+        return {
+            get: key => {
+                if("cobol-lsp.smart-tab" === key) {
+                    return undefined;
+                }
+            }
+        }
+     }
 }
 
 export namespace extensions {
@@ -69,8 +77,9 @@ export enum EndOfLine {
 export const Range = jest.fn().mockImplementation((start, end) => { return { start: start, end: end } })
 export const Position = jest.fn().mockImplementation((line, character) => { return { line: line, character: character } });
 
-export const commands = {
-    registerTextEditorCommand: jest.fn()
+export namespace commands {
+    export const registerTextEditorCommand = jest.fn();
+    export const executeCommand = jest.fn();
 };
 
 export const TextEditor = {
@@ -78,3 +87,15 @@ export const TextEditor = {
         lineAt: jest.fn()
     }
 }
+
+export class Selection {
+    anchor: any;
+    active: any;
+
+    constructor(anchor: any, active: any) {
+        this.anchor = anchor;
+        this.active = active;
+    }
+}
+
+

--- a/clients/cobol-lsp-vscode-extension/src/__tests__/commands/SmartTabCommandTest.spec.ts
+++ b/clients/cobol-lsp-vscode-extension/src/__tests__/commands/SmartTabCommandTest.spec.ts
@@ -16,6 +16,7 @@ import * as vscode from "../../__mocks__/vscode";
 import * as smartTab from "../../commands/SmartTabCommand";
 import {initSmartTab} from "../../commands/SmartTabCommand";
 import { TabRule, TabSettings } from "../../services/Settings";
+import { Position, Selection, TextEditor, TextEditorEdit } from "vscode";
 
 const editor: any = {
     document: {
@@ -47,6 +48,21 @@ test("Default rule was choosen for empty rule list", () => {
 
     expect(rule.stops[0]).toBe(5);
     expect(rule.regex).toBeUndefined();
+});
+
+test("SmartTabCommandProvider execution", async () => {
+    const stp: smartTab.SmartTabCommandProvider = new smartTab.SmartTabCommandProvider(context, "some name");
+    const active: Position = new Position(1, 2);
+    const mockSelection: Selection = new Selection(active, active);
+    const textLine = { text: "" };
+    const mockEditor: TextEditor = {
+        selections: [mockSelection],
+        document: {
+            lineAt: jest.fn().mockReturnValue(textLine),
+        }
+    } as any;
+    stp.execute(mockEditor, { insert: jest.fn() } as any);
+    expect(mockEditor.selections[0].active.character).toBe(6);
 });
 
 test("One of the rule was choosen", () => {

--- a/clients/cobol-lsp-vscode-extension/src/commands/SmartTabCommand.ts
+++ b/clients/cobol-lsp-vscode-extension/src/commands/SmartTabCommand.ts
@@ -51,7 +51,7 @@ abstract class SmartCommandProvider {
     public abstract execute(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, args: any[]);
 }
 
-class SmartTabCommandProvider extends SmartCommandProvider {
+export class SmartTabCommandProvider extends SmartCommandProvider {
     public execute(editor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
         const newSelections: Selection[] = new Array();
 

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -101,12 +101,12 @@ function globSearch(workspaceFolder: string, resource: string, copybookName: str
         }
     }
     // One must use forward-slashes only in glob expressions
-    const cwd = path.resolve(...cwdSegments).replace(backwardSlashRegex, "/");
+    const cwd = path.resolve("/", ...cwdSegments).replace(backwardSlashRegex, "/");
     const normalizePathName = pathName.replace(backwardSlashRegex, "/");
     let pattern = normalizePathName === cwd ? "" : normalizePathName.replace(cwd.endsWith("/") ? cwd : cwd + "/", "");
     const suffix = (pattern.length == 0 || pattern.endsWith("/") ? "" : "/") + copybookName + ext;
     pattern = pattern + suffix;
-    const result = glob.sync(pattern, { cwd });
+    const result = glob.sync(pattern, { cwd, "dot": true });
     // TODO report the case with more then one copybook fit the pattern.
     return result[0] ? path.join(cwd, result[0]) : undefined;
 }

--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -88,15 +88,26 @@ export function searchCopybookInWorkspace(copybookName: string, copybookFolders:
     return undefined;
 }
 
+const backwardSlashRegex = new RegExp("\\\\", "g");
 function globSearch(workspaceFolder: string, resource: string, copybookName: string, ext: string): string | undefined {
     const pathName: string = isAbsolute(resource) ? resource : path.normalize(path.join(workspaceFolder, resource));
-    const cwd = pathName.split("*", 2)[0]
-    let pattern = pathName.replace(cwd, "");
-    // You must use forward-slashes only in glob expressions
-    pattern = pattern.replace("\\", "/");
+    const segments = pathName.split(path.sep);
+    const cwdSegments: string[] = [];
+    for (const s of segments) {
+        if(!glob.hasMagic(s)) {
+            cwdSegments.push(s);
+        } else {
+            break;
+        }
+    }
+    // One must use forward-slashes only in glob expressions
+    const cwd = path.resolve(...cwdSegments).replace(backwardSlashRegex, "/");
+    const normalizePathName = pathName.replace(backwardSlashRegex, "/");
+    let pattern = normalizePathName === cwd ? "" : normalizePathName.replace(cwd.endsWith("/") ? cwd : cwd + "/", "");
     const suffix = (pattern.length == 0 || pattern.endsWith("/") ? "" : "/") + copybookName + ext;
     pattern = pattern + suffix;
     const result = glob.sync(pattern, { cwd });
+    // TODO report the case with more then one copybook fit the pattern.
     return result[0] ? path.join(cwd, result[0]) : undefined;
 }
 


### PR DESCRIPTION
Please test it on windows!
Steps:
1. have a simple COBOL program with a copybook, ("CB1.cpy")
2. specify a path to the copybook folder using glob pattern, for example, "COPYBOO?'
3. Verify that "COPYBOOK/CB1.cpy" is resolved by COBOL LS