### PR TITLE
fix: Reference name even if not unique, provided it has only one 01 l…

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/NodeType.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/NodeType.java
@@ -56,5 +56,6 @@ public enum NodeType {
   SECTION_NAME_NODE,
   CUSTOM,
   OBSOLETE,
-  AT_END
+  AT_END,
+  COMPILER_DIRECTIVE
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/CompilerDirectiveNode.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/model/tree/CompilerDirectiveNode.java
@@ -12,23 +12,20 @@
  *    Broadcom, Inc. - initial API and implementation
  *
  */
-package org.eclipse.lsp.cobol.core.model.tree;
+package org.eclipse.lsp.cobol.common.model.tree;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp.cobol.common.model.Locality;
 import org.eclipse.lsp.cobol.common.model.NodeType;
-import org.eclipse.lsp.cobol.common.model.tree.Node;
-import org.eclipse.lsp.cobol.core.CobolParser;
 
 /** Node describing compiler directive in a cobol document. */
 @Slf4j
 public class CompilerDirectiveNode extends Node {
-  @Getter private final CobolParser.CompilerOptionsContext directiveContext;
+  @Getter private final String directiveText;
 
-  public CompilerDirectiveNode(
-      Locality location, CobolParser.CompilerOptionsContext directiveContext) {
+  public CompilerDirectiveNode(Locality location, String directiveText) {
     super(location, NodeType.COMPILER_DIRECTIVE);
-    this.directiveContext = directiveContext;
+    this.directiveText = directiveText;
   }
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContext.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.common.processor;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Compiler directive context */
+public class CompilerDirectiveContext {
+  @Getter private final List<CompilerDirectiveOption> compilerDirectiveList = new ArrayList<>();
+
+  /**
+   * Updates the compiler directive options
+   *
+   * @param compilerDirectiveOption @{@link CompilerDirectiveOption}
+   */
+  public void updateDirectiveOptions(CompilerDirectiveOption compilerDirectiveOption) {
+    Optional<CompilerDirectiveOption> existingOption =
+        compilerDirectiveList.stream()
+            .filter(
+                options ->
+                    options.getCompilerDirectiveName()
+                        == compilerDirectiveOption.getCompilerDirectiveName())
+            .findFirst();
+    compilerDirectiveList.add(existingOption.orElse(compilerDirectiveOption));
+  }
+
+  /**
+   * Updates the list of compiler directive options
+   *
+   * @param compilerDirectiveOption List of @{@link CompilerDirectiveOption}
+   */
+  public void updateDirectiveOptions(List<CompilerDirectiveOption> compilerDirectiveOption) {
+    compilerDirectiveOption.forEach(this::updateDirectiveOptions);
+  }
+
+  /**
+   * Utility to get filtered list of compiler directive from the context
+   *
+   * @param names List of @{@link CompilerDirectiveName}
+   * @return List of @{@link CompilerDirectiveOption}
+   */
+  public List<CompilerDirectiveOption> filterDirectiveList(List<CompilerDirectiveName> names) {
+    return compilerDirectiveList.stream()
+        .filter(p -> names.contains(p.getCompilerDirectiveName()))
+        .collect(Collectors.toList());
+  }
+}

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.common.processor;
+
+import java.util.Optional;
+
+/**
+ * Compiler directive enum, which needs to be handled for document analysis.
+ *
+ * <p>Add enums, here in case the compiler directives changes the way document is analysed.
+ */
+public enum CompilerDirectiveName {
+  ADATA {
+    @Override
+    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
+      return Optional.empty();
+    }
+  },
+  QUALIFY {
+    @Override
+    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
+      if (directiveText.contains("QUALIFY(EXTEND)"))
+        return Optional.of(new CompilerDirectiveOption<>(true, this));
+      return Optional.empty();
+    }
+  },
+  QUA {
+    @Override
+    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
+      if (directiveText.contains("QUA(EXTEND)"))
+        return Optional.of(new CompilerDirectiveOption<>(true, this));
+      return Optional.empty();
+    }
+  };
+
+  /**
+   * Get the {@link CompilerDirectiveOption} based on the compiler directive text in the document.
+   *
+   * @param directiveText is compiler directive text in the document
+   * @return List of {@link CompilerDirectiveOption}
+   */
+  public abstract Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText);
+}

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveName.java
@@ -24,24 +24,22 @@ import java.util.Optional;
 public enum CompilerDirectiveName {
   ADATA {
     @Override
-    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
+    public Optional<CompilerDirectiveOption<Boolean>> getDirectiveOption(String directiveText) {
       return Optional.empty();
     }
   },
   QUALIFY {
     @Override
-    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
-      if (directiveText.contains("QUALIFY(EXTEND)"))
-        return Optional.of(new CompilerDirectiveOption<>(true, this));
-      return Optional.empty();
+    public Optional<CompilerDirectiveOption<Boolean>> getDirectiveOption(String directiveText) {
+      return Optional.of(new CompilerDirectiveOption<>(true, this))
+              .filter(cd -> directiveText.contains("QUALIFY(EXTEND)"));
     }
   },
   QUA {
     @Override
-    public Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText) {
-      if (directiveText.contains("QUA(EXTEND)"))
-        return Optional.of(new CompilerDirectiveOption<>(true, this));
-      return Optional.empty();
+    public Optional<CompilerDirectiveOption<Boolean>> getDirectiveOption(String directiveText) {
+      return Optional.of(new CompilerDirectiveOption<>(true, this))
+              .filter(cd -> directiveText.contains("QUA(EXTEND)"));
     }
   };
 
@@ -51,5 +49,5 @@ public enum CompilerDirectiveName {
    * @param directiveText is compiler directive text in the document
    * @return List of {@link CompilerDirectiveOption}
    */
-  public abstract Optional<CompilerDirectiveOption> getDirectiveOption(String directiveText);
+  public abstract Optional<CompilerDirectiveOption<Boolean>> getDirectiveOption(String directiveText);
 }

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveOption.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/CompilerDirectiveOption.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.common.processor;
+
+import lombok.Value;
+
+/**
+ * Compiler directive Options
+ *
+ * @param <T> value set corresponding to a compiler directive option.
+ */
+@Value
+public class CompilerDirectiveOption<T> {
+  T value;
+  CompilerDirectiveName compilerDirectiveName;
+}

--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/ProcessingContext.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/processor/ProcessingContext.java
@@ -36,6 +36,7 @@ public class ProcessingContext {
 
     final List<SyntaxError> errors;
     final VariableAccumulator variableAccumulator;
+    private final CompilerDirectiveContext compilerDirectiveContext = new CompilerDirectiveContext();
     /**
      * Register node type processor
      *

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/engine/CobolLanguageEngine.java
@@ -290,6 +290,9 @@ public class CobolLanguageEngine {
   private void registerProcessors(AnalysisConfig analysisConfig, ProcessingContext ctx, SymbolAccumulatorService symbolAccumulatorService) {
     // Phase TRANSFORMATION
     ctx.register(
+            new ProcessorDescription(
+                    CompilerDirectiveNode.class, ProcessingPhase.TRANSFORMATION, new CompilerDirectiveProcess()));
+    ctx.register(
         new ProcessorDescription(
             ProgramIdNode.class, ProcessingPhase.TRANSFORMATION, new ProgramIdProcess()));
     ctx.register(

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/CompilerDirectiveNode.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/CompilerDirectiveNode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+package org.eclipse.lsp.cobol.core.model.tree;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp.cobol.common.model.Locality;
+import org.eclipse.lsp.cobol.common.model.NodeType;
+import org.eclipse.lsp.cobol.common.model.tree.Node;
+import org.eclipse.lsp.cobol.core.CobolParser;
+
+/** Node describing compiler directive in a cobol document. */
+@Slf4j
+public class CompilerDirectiveNode extends Node {
+  @Getter private final CobolParser.CompilerOptionsContext directiveContext;
+
+  public CompilerDirectiveNode(
+      Locality location, CobolParser.CompilerOptionsContext directiveContext) {
+    super(location, NodeType.COMPILER_DIRECTIVE);
+    this.directiveContext = directiveContext;
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/CompilerDirectiveProcess.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/CompilerDirectiveProcess.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.core.model.tree.logic;
+
+import org.eclipse.lsp.cobol.common.processor.*;
+import org.eclipse.lsp.cobol.core.model.tree.CompilerDirectiveNode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Compiler Directives processor */
+public class CompilerDirectiveProcess implements Processor<CompilerDirectiveNode> {
+  /**
+   * Set up the compiler directive context which can be used later in any stage of processing the
+   * documents.
+   *
+   * @param compilerDirectiveNode @{@link CompilerDirectiveNode}
+   * @param processingContext @{@link ProcessingContext}
+   */
+  @Override
+  public void accept(
+      CompilerDirectiveNode compilerDirectiveNode, ProcessingContext processingContext) {
+    String directiveText =
+        compilerDirectiveNode
+            .getDirectiveContext()
+            .getText()
+            .replaceAll("\\s+", "")
+            .toUpperCase(Locale.ROOT);
+    List<CompilerDirectiveOption> directiveOptionsList =
+        Arrays.stream(CompilerDirectiveName.values())
+            .map(val -> val.getDirectiveOption(directiveText))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+    processingContext.getCompilerDirectiveContext().updateDirectiveOptions(directiveOptionsList);
+  }
+}

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/CompilerDirectiveProcess.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/CompilerDirectiveProcess.java
@@ -16,7 +16,7 @@
 package org.eclipse.lsp.cobol.core.model.tree.logic;
 
 import org.eclipse.lsp.cobol.common.processor.*;
-import org.eclipse.lsp.cobol.core.model.tree.CompilerDirectiveNode;
+import org.eclipse.lsp.cobol.common.model.tree.CompilerDirectiveNode;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,9 +37,8 @@ public class CompilerDirectiveProcess implements Processor<CompilerDirectiveNode
   public void accept(
       CompilerDirectiveNode compilerDirectiveNode, ProcessingContext processingContext) {
     String directiveText =
-        compilerDirectiveNode
-            .getDirectiveContext()
-            .getText()
+            compilerDirectiveNode
+            .getDirectiveText()
             .replaceAll("\\s+", "")
             .toUpperCase(Locale.ROOT);
     List<CompilerDirectiveOption> directiveOptionsList =

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/QualifiedReferenceUpdateVariableUsage.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/model/tree/logic/QualifiedReferenceUpdateVariableUsage.java
@@ -22,6 +22,9 @@ import org.eclipse.lsp.cobol.common.error.SyntaxError;
 import org.eclipse.lsp.cobol.common.message.MessageTemplate;
 import org.eclipse.lsp.cobol.common.model.tree.Node;
 import org.eclipse.lsp.cobol.common.model.NodeType;
+import org.eclipse.lsp.cobol.common.model.tree.variable.VariableWithLevelNode;
+import org.eclipse.lsp.cobol.common.processor.CompilerDirectiveName;
+import org.eclipse.lsp.cobol.common.processor.CompilerDirectiveOption;
 import org.eclipse.lsp.cobol.common.processor.ProcessingContext;
 import org.eclipse.lsp.cobol.common.processor.Processor;
 import org.eclipse.lsp.cobol.core.engine.symbols.SymbolAccumulatorService;
@@ -56,6 +59,17 @@ public class QualifiedReferenceUpdateVariableUsage implements Processor<Qualifie
             .filter(Node.hasType(NodeType.VARIABLE_USAGE))
             .map(VariableUsageNode.class::cast)
             .collect(Collectors.toList());
+
+    boolean isQualifyExtendedDirectiveEnabled =
+        ctx
+            .getCompilerDirectiveContext()
+            .filterDirectiveList(
+                ImmutableList.of(CompilerDirectiveName.QUALIFY, CompilerDirectiveName.QUA))
+            .stream()
+            .findFirst()
+            .map(CompilerDirectiveOption<Boolean>::getValue)
+            .orElse(false);
+
     if (variableUsageNodes.isEmpty()) {
       LOG.warn("Qualified reference node don't have any variable usages. {}", node);
       return;
@@ -64,13 +78,18 @@ public class QualifiedReferenceUpdateVariableUsage implements Processor<Qualifie
     List<VariableNode> foundDefinitions =
         node.getProgram()
             .map(
-                programNode -> symbolAccumulatorService.getVariableDefinition(programNode, variableUsageNodes))
+                programNode ->
+                    symbolAccumulatorService.getVariableDefinition(programNode, variableUsageNodes))
             .orElseGet(ImmutableList::of);
 
+    if (isQualifyExtendedDirectiveEnabled && foundDefinitions.size() > 1) {
+      foundDefinitions = updateDefinitionForQualifyExtended(node, foundDefinitions);
+    }
     for (VariableNode definitionNode : foundDefinitions) {
       node.setVariableDefinitionNode(definitionNode);
       for (VariableUsageNode usageNode : variableUsageNodes) {
-        while (definitionNode != null && !usageNode.getName().equalsIgnoreCase(definitionNode.getName())) {
+        while (definitionNode != null
+            && !usageNode.getName().equalsIgnoreCase(definitionNode.getName())) {
           definitionNode =
               definitionNode
                   .getNearestParentByType(NodeType.VARIABLE)
@@ -113,5 +132,19 @@ public class QualifiedReferenceUpdateVariableUsage implements Processor<Qualifie
             .build();
     ctx.getErrors().add(error);
     LOG.debug("Syntax error by QualifiedReferenceNode " + error.toString());
+  }
+
+  private List<VariableNode> updateDefinitionForQualifyExtended(QualifiedReferenceNode node, List<VariableNode> foundDefinitions) {
+    List<VariableNode> definitionWithLevel01 =
+        foundDefinitions.stream()
+            .filter(VariableWithLevelNode.class::isInstance)
+            .map(VariableWithLevelNode.class::cast)
+            .filter(n -> n.getLevel() == 1)
+            .collect(Collectors.toList());
+    if (definitionWithLevel01.size() == 1) {
+      foundDefinitions = definitionWithLevel01;
+      node.setVariableDefinitionNode(definitionWithLevel01.get(0));
+    }
+    return foundDefinitions;
   }
 }

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
@@ -157,7 +157,7 @@ public class CobolVisitor extends CobolParserBaseVisitor<List<Node>> {
    */
   @Override
   public List<Node> visitCompilerOptions(CompilerOptionsContext ctx) {
-    return addTreeNode(ctx, location -> new CompilerDirectiveNode(location, ctx));
+    return addTreeNode(ctx, location -> new CompilerDirectiveNode(location, ctx.getText()));
   }
 
   @Override

--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/core/visitor/CobolVisitor.java
@@ -147,6 +147,19 @@ public class CobolVisitor extends CobolParserBaseVisitor<List<Node>> {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   *
+   * @param ctx
+   */
+  @Override
+  public List<Node> visitCompilerOptions(CompilerOptionsContext ctx) {
+    return addTreeNode(ctx, location -> new CompilerDirectiveNode(location, ctx));
+  }
+
   @Override
   public List<Node> visitIdentificationDivision(IdentificationDivisionContext ctx) {
     areaAWarning(ctx.getStart());

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestQualifyExtendedImpactOnVariableDefinition.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestQualifyExtendedImpactOnVariableDefinition.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.common.error.ErrorSource;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests if there is only one 01 level with a given name, that name can be referenced even if it is
+ * not unique when the QUALIFY(EXTEND) option is in effect.
+ *
+ * <p>Ref - https://www.ibm.com/docs/en/cobol-zos/6.3?topic=reference-qualification
+ */
+public class TestQualifyExtendedImpactOnVariableDefinition {
+  public static final String TEXT_WITH_EXTENDED_OPTION =
+      "PROCESS PGMN(LM),DYNAM,QUALIFY(EXTEND),SSRANGE(ZLEN)\n"
+          + "\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. 'demo' RECURSIVE.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       LOCAL-STORAGE SECTION.\n"
+          + "       LINKAGE SECTION.\n"
+          + "       1 {$*s}.\n"
+          + "         3 {$*data1}.\n"
+          + "           5 {$*value1} USAGE POINTER.\n"
+          + "           5 {$*size1} PIC S9(9) COMP-5.\n"
+          + "           5 {$*capacity} PIC S9(9) COMP-5.\n"
+          + "       1 {$*value1}.\n"
+          + "         3 {$*ptr} USAGE POINTER.\n"
+          + "         3 {$*siz} PIC S9(9) COMP-5.\n"
+          + "       PROCEDURE DIVISION USING {$s} {$value1}.\n"
+          + "           >>CALLINTERFACE STATIC\n"
+          + "           CALL {%\"something\"} USING {$data1} IN {$s} {$value1}\n"
+          + "           >>CALLINTERFACE DYNAMIC\n"
+          + "           GOBACK.\n"
+          + "       END PROGRAM 'demo'.\n";
+
+  public static final String TEXT_WITHOUT_EXTENDED_OPTION =
+      "PROCESS PGMN(LM),DYNAM,SSRANGE(ZLEN)\n"
+          + "\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. 'demo' RECURSIVE.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       LOCAL-STORAGE SECTION.\n"
+          + "       LINKAGE SECTION.\n"
+          + "       1 {$*s}.\n"
+          + "         3 {$*data1}.\n"
+          + "           5 {$*value1} USAGE POINTER.\n"
+          + "           5 {$*size1} PIC S9(9) COMP-5.\n"
+          + "           5 {$*capacity} PIC S9(9) COMP-5.\n"
+          + "       1 {$*value1}.\n"
+          + "         3 {$*ptr} USAGE POINTER.\n"
+          + "         3 {$*siz} PIC S9(9) COMP-5.\n"
+          + "       PROCEDURE DIVISION USING {$s} {$value1|1}.\n"
+          + "           >>CALLINTERFACE STATIC\n"
+          + "           CALL {%\"something\"} USING {$data1} IN {$s} {$value1|2}\n"
+          + "           >>CALLINTERFACE DYNAMIC\n"
+          + "           GOBACK.\n"
+          + "       END PROGRAM 'demo'.\n";
+  private static final String TEXT_WITH_EXTENDED_OPTION_WITHOUT_01_LEVEL =
+      "PROCESS PGMN(LM),DYNAM,QUALIFY(EXTEND),SSRANGE(ZLEN)\n"
+          + "\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. 'demo' RECURSIVE.\n"
+          + "       ENVIRONMENT DIVISION.\n"
+          + "       INPUT-OUTPUT SECTION.\n"
+          + "       FILE-CONTROL.\n"
+          + "       DATA DIVISION.\n"
+          + "       FILE SECTION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       LOCAL-STORAGE SECTION.\n"
+          + "       LINKAGE SECTION.\n"
+          + "       1 {$*s}.\n"
+          + "         3 {$*data1}.\n"
+          + "           5 {$*value1} USAGE POINTER.\n"
+          + "           5 {$*size1} PIC S9(9) COMP-5.\n"
+          + "           5 {$*capacity} PIC S9(9) COMP-5.\n"
+          + "       1 {$*value1}.\n"
+          + "         3 {$*size1} USAGE POINTER.\n"
+          + "         3 {$*ptr} USAGE POINTER.\n"
+          + "         3 {$*siz} PIC S9(9) COMP-5.\n"
+          + "       PROCEDURE DIVISION USING {$s} {$value1}.\n"
+          + "           >>CALLINTERFACE STATIC\n"
+          + "           CALL {%\"something\"} USING {$data1} IN {$s} {$size1|1}\n"
+          + "           >>CALLINTERFACE DYNAMIC\n"
+          + "           GOBACK.\n"
+          + "       END PROGRAM 'demo'.\n";
+
+  @Test
+  void whenQualifyExtendedOptionActiveWithMultipleDefinitionThenConsider01LevelAsDefinition() {
+    UseCaseEngine.runTest(
+        TEXT_WITH_EXTENDED_OPTION,
+        ImmutableList.of(),
+        ImmutableMap.of(),
+        ImmutableList.of("SOMETHING"));
+  }
+
+  @Test
+  void whenQualifyExtendedOptionActiveWithMultipleDefinitionThrowErrorIfDefNot01() {
+    UseCaseEngine.runTest(
+        TEXT_WITH_EXTENDED_OPTION_WITHOUT_01_LEVEL,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Ambiguous reference for SIZE1",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())),
+        ImmutableList.of("SOMETHING"));
+  }
+
+  @Test
+  void whenQualifyExtendedOptionInActiveWithMultipleDefinitionThenGiveError() {
+    UseCaseEngine.runTest(
+        TEXT_WITHOUT_EXTENDED_OPTION,
+        ImmutableList.of(),
+        ImmutableMap.of(
+            "1",
+            new Diagnostic(
+                new Range(),
+                "Ambiguous reference for VALUE1",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText()),
+            "2",
+            new Diagnostic(
+                new Range(),
+                "Ambiguous reference for VALUE1",
+                DiagnosticSeverity.Error,
+                ErrorSource.PARSING.getText())),
+        ImmutableList.of("SOMETHING"));
+  }
+}


### PR DESCRIPTION
…evel

If there is only one 01 level with a given name, that name can be referenced even if it is not unique when the QUALIFY(EXTEND) option is in effect.
Ref -
https://www.ibm.com/docs/en/cobol-zos/6.3?topic=reference-qualification

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>