### PR TITLE
fix: support utf literal

### DIFF
--- a/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
+++ b/server/engine/src/main/antlr4/org/eclipse/lsp/cobol/core/parser/CobolParser.g4
@@ -2350,8 +2350,13 @@ cicsDfhValueLiteral
 cics_conditions: EOC | EODS | INVMPSZ | INVPARTN | INVREQ | MAPFAIL | PARTNFAIL | RDATT | UNEXPIN;
 
 literal
-   : NONNUMERICLITERAL | figurativeConstant | numericLiteral | booleanLiteral | charString | cicsDfhRespLiteral | cicsDfhValueLiteral
+   : NONNUMERICLITERAL | figurativeConstant | numericLiteral | booleanLiteral | charString | cicsDfhRespLiteral
+   | cicsDfhValueLiteral | utfLiteral | hexadecimalUtfLiteral
    ;
+
+utfLiteral: U_CHAR NONNUMERICLITERAL;
+
+hexadecimalUtfLiteral: U_CHAR HEX_NUMBERS;
 
 charString
    : FINALCHARSTRING

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestUtfLiteral.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestUtfLiteral.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+/** Tests the utf literal usage. */
+public class TestUtfLiteral {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. TEST1.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01  {$*A1} PIC U(1).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           MOVE u'[' TO {$A1}.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
support utf literal.
Ref - https://www.ibm.com/docs/en/cobol-zos/6.3?topic=cobol-using-utf-8-literals

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>