### PR TITLE
fix: Support same program id for multiple programs in same document

### DIFF
--- a/server/common/src/main/java/org/eclipse/lsp/cobol/common/symbols/SymbolTable.java
+++ b/server/common/src/main/java/org/eclipse/lsp/cobol/common/symbols/SymbolTable.java
@@ -40,6 +40,6 @@ public class SymbolTable {
    * @return string value of a generated key
    */
   public static String generateKey(ProgramNode program) {
-    return program.getProgramName() + "%" + program.getLocality().getUri();
+    return program.getProgramName() + "%" + program.getLocality().getUri() + "%" + program.getLocality().getRange();
   }
 }

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMultipleProgramInADocument.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMultipleProgramInADocument.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
 import org.junit.jupiter.api.Test;
 
+/** Tests a single document can have multiple programs with same program id. */
 public class TestMultipleProgramInADocument {
   public static final String TEXT =
       "       IDENTIFICATION DIVISION.\n"

--- a/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMultipleProgramInADocument.java
+++ b/server/engine/src/test/java/org/eclipse/lsp/cobol/usecases/TestMultipleProgramInADocument.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Broadcom, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.lsp.cobol.usecases;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.lsp.cobol.test.engine.UseCaseEngine;
+import org.junit.jupiter.api.Test;
+
+public class TestMultipleProgramInADocument {
+  public static final String TEXT =
+      "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. CONDS.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-NUM1} PIC 9(9).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           MOVE 0 to {$WS-NUM1}.\n"
+          + "       END PROGRAM CONDS.\n"
+          + "\n"
+          + "\n"
+          + "       IDENTIFICATION DIVISION.\n"
+          + "       PROGRAM-ID. CONDS.\n"
+          + "       DATA DIVISION.\n"
+          + "       WORKING-STORAGE SECTION.\n"
+          + "       01 {$*WS-NUM1} PIC 9(9).\n"
+          + "       PROCEDURE DIVISION.\n"
+          + "           MOVE 0 to {$WS-NUM1}.\n"
+          + "       END PROGRAM CONDS.";
+
+  @Test
+  void test() {
+    UseCaseEngine.runTest(TEXT, ImmutableList.of(), ImmutableMap.of());
+  }
+}


### PR DESCRIPTION
Support same program id for multiple programs in same document

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>