### PR TITLE
fix: do not show progress notification for copybooks

### DIFF
--- a/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
+++ b/server/engine/src/main/java/org/eclipse/lsp/cobol/service/CobolTextDocumentService.java
@@ -648,7 +648,11 @@ public class CobolTextDocumentService implements TextDocumentService, ExtendedAp
   public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
       DocumentSymbolParams params) {
     String uri = params.getTextDocument().getUri();
-    communications.notifyProgressBegin(uri);
+    Path file = fileSystemService.getPathFromURI(uri);
+    String text = fileSystemService.getContentByPath(Objects.requireNonNull(file));
+    if (!copybookIdentificationService.isCopybook(uri, text, copybookExtensions)) {
+      communications.notifyProgressBegin(uri);
+    }
     return outlineMap
         .get(uri)
         .thenApply(


### PR DESCRIPTION
do not show progress notification for copybooks as we don't analyse copybooks.

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>