### PR TITLE
fix: Add empty sting as default for copybook extensions

### DIFF
--- a/clients/cobol-lsp-vscode-extension/package.json
+++ b/clients/cobol-lsp-vscode-extension/package.json
@@ -221,16 +221,18 @@
                 },
                 "cobol-lsp.cpy-manager.copybook-extensions": {
                     "type": "array",
+                    "$comment": "Items is converted to an array instead of simple string, to disable the vscode rendering the form for extensions setting, instead shows an hyper link to settings.xml for editing.This is done as empty string is not supported by vscode yet",
                     "items": {
-                        "type": "string"
+                        "type": ["string"] 
                     },
                     "default": [
                         ".CPY",
                         ".COPY",
                         ".cpy",
-                        ".copy"
+                        ".copy",
+                        ""
                     ],
-                    "description": "List of copybook extensions",
+                    "description": "List of copybook extensions. Empty string specifies no file extension.",
                     "uniqueItems": true
                 },
                 "cobol-lsp.cpy-manager.copybook-file-encoding": {


### PR DESCRIPTION
Add empty sting as default for copybook extensions

Signed-off-by: Aman Prashant <aman.prashant@broadcom.com>