### PR TITLE
Fix: support folders with special (url) characters

### DIFF
--- a/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
+++ b/clients/cobol-lsp-vscode-extension/src/services/util/FSUtils.ts
@@ -80,7 +80,9 @@ export function searchCopybookInWorkspace(copybookName: string, copybookFolders:
             for (const ext of extensions) {
                 const searchResult = globSearch(workspaceFolder, p, copybookName, ext);
                 if (searchResult) {
-                    return new urlUtil.URL("file://" + searchResult).href;
+                    const root = path.parse(searchResult).root;
+                    const urlPath = searchResult.substring(root.length).split(path.sep).map(s => encodeURIComponent(s)).join(path.sep);
+                    return new urlUtil.URL("file://" + root + urlPath).href;
                 }
             }
         }


### PR DESCRIPTION
An issue: local copybook resolution doesn't work for special characters like %, #, $

Steps to test:
1. Create a folder with a special character in the name
2. Add it to the local copybooks path
3. Add a copybook to this folder
4. Use this copybook in a COBOL program

Expected:
- copybook is resolved